### PR TITLE
fix: ボタンデザインを btn クラスに統一

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,3 +28,5 @@ services:
       - "3000:3000"
     depends_on:
       - backend
+    volumes:
+      - ./frontapp-react/src:/app/src

--- a/frontapp-react/src/ListMemos.jsx
+++ b/frontapp-react/src/ListMemos.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import "./styles.css";
 import { BASE_URL } from "./utils/api";
 
@@ -23,6 +23,7 @@ function priorityBadge(priority) {
 }
 
 function ListMemos() {
+  const navigate = useNavigate();
   const [memos, setMemos] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
@@ -118,11 +119,14 @@ function ListMemos() {
                       {createdAt && <span>作成: {createdAt}</span>}
                     </div>
                     <div className="memo-actions">
-                      <Link to={`/memos/${m.memo_id}/edit`} className="btn-icon">
-                        編集
-                      </Link>
                       <button
-                        className="btn-danger-icon"
+                        className="btn btn-sm btn-outline-primary"
+                        onClick={() => navigate(`/memos/${m.memo_id}/edit`)}
+                      >
+                        編集
+                      </button>
+                      <button
+                        className="btn btn-sm btn-danger"
                         onClick={() => handleDelete(m.memo_id)}
                       >
                         削除

--- a/frontapp-react/src/components/MemoForm.jsx
+++ b/frontapp-react/src/components/MemoForm.jsx
@@ -95,7 +95,7 @@ function MemoForm({
         </div>
 
         <div className="form-actions">
-          <button type="submit" className="btn btn-success" disabled={submitting}>
+          <button type="submit" className="btn btn-primary" disabled={submitting}>
             {submitting ? "送信中..." : submitLabel}
           </button>
         </div>

--- a/frontapp-react/src/styles.css
+++ b/frontapp-react/src/styles.css
@@ -98,33 +98,28 @@ body {
   background-color: #eff6ff;
 }
 
-.btn-icon {
-  background: transparent;
-  border: none;
-  color: #6b7280;
-  cursor: pointer;
-  padding: 4px 8px;
-  border-radius: 6px;
-  font-size: 13px;
-  transition: background-color 0.15s;
+.btn-outline-primary {
+  background-color: transparent;
+  color: #2563eb;
+  border: 1px solid #2563eb;
 }
-.btn-icon:hover {
-  background-color: #f3f4f6;
-  color: #374151;
+.btn-outline-primary:hover {
+  background-color: #eff6ff;
 }
 
-.btn-danger-icon {
-  background: transparent;
-  border: none;
-  color: #dc2626;
-  cursor: pointer;
-  padding: 4px 8px;
-  border-radius: 6px;
-  font-size: 13px;
-  transition: background-color 0.15s;
+.btn-danger {
+  background-color: #dc2626;
+  color: #ffffff;
+  border: 1px solid #dc2626;
 }
-.btn-danger-icon:hover {
-  background-color: #fef2f2;
+.btn-danger:hover {
+  opacity: 0.88;
+}
+
+/* サイズ修飾子 */
+.btn-sm {
+  font-size: 12px;
+  padding: 5px 12px;
 }
 
 .btn:disabled {


### PR DESCRIPTION
## 概要

編集・削除・登録・更新ボタンのデザインと実装を統一しました。

---

## 問題

| ボタン | 変更前の実装 | 問題点 |
|---|---|---|
| 編集 | `<Link>` + `btn-icon` | `<a>` タグでレンダリングされ、ボタンではなくリンク |
| 削除 | `<button>` + `btn-danger-icon` | 枠なし・赤テキストのみ |
| 登録 | `<button>` + `btn btn-success` | 緑の塗りつぶし |
| 更新 | `<button>` + `btn btn-success` | 緑の塗りつぶし |

---

## 変更内容

### ボタン実装の統一

| ボタン | 変更後 | 変更点 |
|---|---|---|
| 編集 | `<button>` + `btn btn-sm btn-outline-primary` | `<a>` → `<button>` + `useNavigate` に変更 |
| 削除 | `<button>` + `btn btn-sm btn-danger` | 赤塗りつぶしに変更 |
| 登録 | `<button>` + `btn btn-primary` | 緑 → 青に統一 |
| 更新 | `<button>` + `btn btn-primary` | 緑 → 青に統一 |

### CSS 変更

- 追加: `btn-outline-primary`（青枠・透明背景）
- 追加: `btn-danger`（赤塗りつぶし）
- 追加: `btn-sm`（カード内アクション用の小サイズ）
- 削除: `btn-icon`（未使用）
- 削除: `btn-danger-icon`（未使用）

### 開発環境改善

- `docker-compose.yml` に `src/` のボリュームマウントを追加
- ソース変更時に `docker compose up --build` の再実行が不要になる

---

## テスト確認

- [x] フロントエンドのコンパイル成功を確認
- [x] 編集ボタンで編集ページへ遷移することを確認
- [x] 削除ボタンで確認ダイアログが表示されることを確認
- [x] 登録・更新ボタンで送信されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)