### PR TITLE
feat: FastAPI + JWT 認証機能を実装

### DIFF
--- a/auth.py
+++ b/auth.py
@@ -1,0 +1,54 @@
+import os
+from datetime import datetime, timedelta
+from jose import JWTError, jwt
+from passlib.context import CryptContext
+from fastapi import Depends, HTTPException, status
+from fastapi.security import OAuth2PasswordBearer
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
+import db
+import models.user as user_model
+
+SECRET_KEY = os.environ.get("SECRET_KEY", "change-me-in-production")
+ALGORITHM = "HS256"
+ACCESS_TOKEN_EXPIRE_MINUTES = 60 * 24  # 24時間
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/auth/login")
+
+
+def hash_password(password: str) -> str:
+    return pwd_context.hash(password)
+
+
+def verify_password(plain: str, hashed: str) -> bool:
+    return pwd_context.verify(plain, hashed)
+
+
+def create_access_token(user_id: int) -> str:
+    expire = datetime.utcnow() + timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
+    return jwt.encode({"sub": str(user_id), "exp": expire}, SECRET_KEY, algorithm=ALGORITHM)
+
+
+async def get_current_user(
+    token: str = Depends(oauth2_scheme),
+    session: AsyncSession = Depends(db.get_dbsession),
+) -> user_model.User:
+    credentials_exception = HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="認証情報が無効です",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+    try:
+        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+        user_id = int(payload.get("sub"))
+    except (JWTError, TypeError, ValueError):
+        raise credentials_exception
+
+    result = await session.execute(
+        select(user_model.User).where(user_model.User.user_id == user_id)
+    )
+    user = result.scalars().first()
+    if not user:
+        raise credentials_exception
+    return user

--- a/cruds/memo.py
+++ b/cruds/memo.py
@@ -6,45 +6,57 @@ from datetime import datetime
 
 
 async def insert_memo(
-        db_session: AsyncSession,
-        memo_data: memo_schema.InsertAndUpdateMemoSchema) -> memo_model.Memo:
+        session: AsyncSession,
+        memo_data: memo_schema.InsertAndUpdateMemoSchema,
+        user_id: int) -> memo_model.Memo:
     new_memo = memo_model.Memo(
+        user_id=user_id,
         title=memo_data.title,
         description=memo_data.description,
         priority=memo_data.status.priority,
         due_date=memo_data.status.due_date,
         is_completed=memo_data.status.is_completed,
     )
-    db_session.add(new_memo)
-    await db_session.commit()
-    await db_session.refresh(new_memo)
+    session.add(new_memo)
+    await session.commit()
+    await session.refresh(new_memo)
     return new_memo
 
 
 async def get_memos(
-    db_session: AsyncSession,
+    session: AsyncSession,
+    user_id: int,
     skip: int = 0,
     limit: int = 50,
 ) -> list[memo_model.Memo]:
-    result = await db_session.execute(
-        select(memo_model.Memo).offset(skip).limit(limit)
+    result = await session.execute(
+        select(memo_model.Memo)
+        .where(memo_model.Memo.user_id == user_id)
+        .offset(skip)
+        .limit(limit)
     )
     return result.scalars().all()
 
 
-async def get_memo_by_id(db_session: AsyncSession,
-        memo_id: int) -> memo_model.Memo | None:
-    result = await db_session.execute(
-        select(memo_model.Memo).where(memo_model.Memo.memo_id == memo_id)
+async def get_memo_by_id(
+        session: AsyncSession,
+        memo_id: int,
+        user_id: int) -> memo_model.Memo | None:
+    result = await session.execute(
+        select(memo_model.Memo).where(
+            memo_model.Memo.memo_id == memo_id,
+            memo_model.Memo.user_id == user_id,
+        )
     )
     return result.scalars().first()
 
 
 async def update_memo(
-        db_session: AsyncSession,
+        session: AsyncSession,
         memo_id: int,
-        target_data: memo_schema.InsertAndUpdateMemoSchema) -> memo_model.Memo | None:
-    memo = await get_memo_by_id(db_session, memo_id)
+        target_data: memo_schema.InsertAndUpdateMemoSchema,
+        user_id: int) -> memo_model.Memo | None:
+    memo = await get_memo_by_id(session, memo_id, user_id)
     if memo:
         memo.title = target_data.title
         memo.description = target_data.description
@@ -52,27 +64,32 @@ async def update_memo(
         memo.priority = target_data.status.priority
         memo.due_date = target_data.status.due_date
         memo.is_completed = target_data.status.is_completed
-        await db_session.commit()
-        await db_session.refresh(memo)
+        await session.commit()
+        await session.refresh(memo)
     return memo
 
 
 async def delete_memo(
-        db_session: AsyncSession, memo_id: int
-        ) -> memo_model.Memo | None:
-    memo = await get_memo_by_id(db_session, memo_id)
+        session: AsyncSession,
+        memo_id: int,
+        user_id: int) -> memo_model.Memo | None:
+    memo = await get_memo_by_id(session, memo_id, user_id)
     if memo:
-        await db_session.delete(memo)
-        await db_session.commit()
+        await session.delete(memo)
+        await session.commit()
     return memo
 
 
-async def patch_memo(db: AsyncSession, memo_id: int, patch_data: dict):
-    memo = await db.get(memo_model.Memo, memo_id)
+async def patch_memo(
+        session: AsyncSession,
+        memo_id: int,
+        patch_data: dict,
+        user_id: int) -> memo_model.Memo | None:
+    memo = await get_memo_by_id(session, memo_id, user_id)
     if not memo:
         return None
     for key, value in patch_data.items():
         setattr(memo, key, value)
-    await db.commit()
-    await db.refresh(memo)
+    await session.commit()
+    await session.refresh(memo)
     return memo

--- a/cruds/user.py
+++ b/cruds/user.py
@@ -1,0 +1,23 @@
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+import models.user as user_model
+import schemas.user as user_schema
+from auth import hash_password
+
+
+async def get_user_by_email(session: AsyncSession, email: str) -> user_model.User | None:
+    result = await session.execute(
+        select(user_model.User).where(user_model.User.email == email)
+    )
+    return result.scalars().first()
+
+
+async def create_user(session: AsyncSession, data: user_schema.RegisterSchema) -> user_model.User:
+    user = user_model.User(
+        email=data.email,
+        hashed_password=hash_password(data.password),
+    )
+    session.add(user)
+    await session.commit()
+    await session.refresh(user)
+    return user

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,7 @@ services:
       - db
     environment:
       DATABASE_URL: postgresql+asyncpg://fastapi_user:kh817012@db:5432/fastapi_db
+      SECRET_KEY: change-me-in-production
   frontend:
     build:
       context: ./frontapp-react

--- a/frontapp-react/src/App.jsx
+++ b/frontapp-react/src/App.jsx
@@ -1,17 +1,30 @@
 import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
+import { isLoggedIn } from "./utils/auth";
 import CreateMemo from "./CreateMemo";
 import ListMemos from "./ListMemos";
-import EditMemo from "./EditMemo"; 
+import EditMemo from "./EditMemo";
+import Login from "./Login";
+import Register from "./Register";
+
+function PrivateRoute({ children }) {
+  return isLoggedIn() ? children : <Navigate to="/login" replace />;
+}
+
+function PublicOnlyRoute({ children }) {
+  return isLoggedIn() ? <Navigate to="/list" replace /> : children;
+}
 
 function App() {
   return (
     <BrowserRouter>
       <Routes>
+        <Route path="/login" element={<PublicOnlyRoute><Login /></PublicOnlyRoute>} />
+        <Route path="/register" element={<PublicOnlyRoute><Register /></PublicOnlyRoute>} />
         <Route path="/" element={<Navigate to="/list" replace />} />
-        <Route path="/list" element={<ListMemos />} />
-        <Route path="/create" element={<CreateMemo />} />
-        <Route path="/memos/:id/edit" element={<EditMemo />} />
-         <Route path="*" element={<Navigate to="/list" replace />} />
+        <Route path="/list" element={<PrivateRoute><ListMemos /></PrivateRoute>} />
+        <Route path="/create" element={<PrivateRoute><CreateMemo /></PrivateRoute>} />
+        <Route path="/memos/:id/edit" element={<PrivateRoute><EditMemo /></PrivateRoute>} />
+        <Route path="*" element={<Navigate to="/list" replace />} />
       </Routes>
     </BrowserRouter>
   );

--- a/frontapp-react/src/CreateMemo.jsx
+++ b/frontapp-react/src/CreateMemo.jsx
@@ -2,9 +2,10 @@ import { useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import MemoForm from "./components/MemoForm";
 import ErrorBox from "./components/ErrorBox";
+import Header from "./components/Header";
 import { formatApiError } from "./utils/apiError";
 import { validateMemo } from "./utils/validation";
-import { BASE_URL } from "./utils/api";
+import { BASE_URL, authFetch } from "./utils/api";
 
 function CreateMemo() {
   const navigate = useNavigate();
@@ -34,7 +35,7 @@ function CreateMemo() {
         },
       };
 
-      const res = await fetch(`${BASE_URL}/memos/`, {
+      const res = await authFetch(`${BASE_URL}/memos/`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(payload),
@@ -58,9 +59,7 @@ function CreateMemo() {
 
   return (
     <>
-      <header className="app-header">
-        <h1>メモアプリ</h1>
-      </header>
+      <Header />
 
       <main className="page">
         <div className="page-header">

--- a/frontapp-react/src/EditMemo.jsx
+++ b/frontapp-react/src/EditMemo.jsx
@@ -2,9 +2,10 @@ import { useEffect, useState } from "react";
 import { Link, useParams, useNavigate } from "react-router-dom";
 import MemoForm from "./components/MemoForm";
 import ErrorBox from "./components/ErrorBox";
+import Header from "./components/Header";
 import { formatApiError } from "./utils/apiError";
 import { validateMemo } from "./utils/validation";
-import { BASE_URL } from "./utils/api";
+import { BASE_URL, authFetch } from "./utils/api";
 
 function EditMemo() {
   const { id } = useParams();
@@ -20,7 +21,7 @@ function EditMemo() {
       try {
         setLoading(true);
         setError("");
-        const res = await fetch(`${BASE_URL}/memos/${id}`);
+        const res = await authFetch(`${BASE_URL}/memos/${id}`);
         if (!res.ok) throw new Error(`取得に失敗しました (status: ${res.status})`);
 
         const data = await res.json();
@@ -65,7 +66,7 @@ function EditMemo() {
         },
       };
 
-      const res = await fetch(`${BASE_URL}/memos/${id}`, {
+      const res = await authFetch(`${BASE_URL}/memos/${id}`, {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(payload),
@@ -89,23 +90,21 @@ function EditMemo() {
 
   if (loading) return (
     <>
-      <header className="app-header"><h1>メモアプリ</h1></header>
+      <Header />
       <div className="page"><p>読み込み中...</p></div>
     </>
   );
 
   if (!initialValues) return (
     <>
-      <header className="app-header"><h1>メモアプリ</h1></header>
+      <Header />
       <div className="page"><p>データが取得できませんでした</p></div>
     </>
   );
 
   return (
     <>
-      <header className="app-header">
-        <h1>メモアプリ</h1>
-      </header>
+      <Header />
 
       <main className="page">
         <div className="page-header">

--- a/frontapp-react/src/ListMemos.jsx
+++ b/frontapp-react/src/ListMemos.jsx
@@ -1,7 +1,8 @@
 import { useEffect, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import "./styles.css";
-import { BASE_URL } from "./utils/api";
+import { BASE_URL, authFetch } from "./utils/api";
+import Header from "./components/Header";
 
 function formatDate(value) {
   if (!value) return null;
@@ -34,7 +35,7 @@ function ListMemos() {
       try {
         setLoading(true);
         setError("");
-        const res = await fetch(`${BASE_URL}/memos/`);
+        const res = await authFetch(`${BASE_URL}/memos/`);
         if (!res.ok) throw new Error(`取得失敗 (status: ${res.status})`);
         const data = await res.json();
         setMemos(Array.isArray(data) ? data : []);
@@ -50,7 +51,7 @@ function ListMemos() {
   const handleDelete = async (id) => {
     if (!window.confirm("本当に削除しますか？")) return;
     try {
-      const res = await fetch(`${BASE_URL}/memos/${id}`, { method: "DELETE" });
+      const res = await authFetch(`${BASE_URL}/memos/${id}`, { method: "DELETE" });
       if (!res.ok) throw new Error(`削除失敗 (status: ${res.status})`);
       setMemos((prev) => prev.filter((m) => m.memo_id !== id));
       setSuccessMsg("メモを削除しました");
@@ -62,16 +63,14 @@ function ListMemos() {
 
   if (loading) return (
     <>
-      <header className="app-header"><h1>メモアプリ</h1></header>
+      <Header />
       <div className="page"><p>読み込み中...</p></div>
     </>
   );
 
   return (
     <>
-      <header className="app-header">
-        <h1>メモアプリ</h1>
-      </header>
+      <Header />
 
       <main className="page">
         <div className="page-header">

--- a/frontapp-react/src/Login.jsx
+++ b/frontapp-react/src/Login.jsx
@@ -1,0 +1,93 @@
+import { useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import { BASE_URL } from "./utils/api";
+import { setToken } from "./utils/auth";
+import "./styles.css";
+
+function Login() {
+  const navigate = useNavigate();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError("");
+    setSubmitting(true);
+    try {
+      const res = await fetch(`${BASE_URL}/auth/login`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email, password }),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.detail || "ログインに失敗しました");
+      }
+      const data = await res.json();
+      setToken(data.access_token);
+      navigate("/list");
+    } catch (e) {
+      setError(e.message);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <>
+      <header className="app-header">
+        <h1>メモアプリ</h1>
+      </header>
+
+      <main className="page">
+        <div className="form-card" style={{ maxWidth: 400, margin: "0 auto" }}>
+          <h2 className="page-title" style={{ marginBottom: "1.5rem" }}>ログイン</h2>
+
+          {error && <div className="alert-error" style={{ marginBottom: "1rem" }}>{error}</div>}
+
+          <form onSubmit={handleSubmit}>
+            <div className="form-group">
+              <label className="form-label">メールアドレス</label>
+              <input
+                className="form-input"
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                required
+                autoFocus
+              />
+            </div>
+            <div className="form-group">
+              <label className="form-label">パスワード</label>
+              <input
+                className="form-input"
+                type="password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                required
+                minLength={8}
+              />
+            </div>
+            <button
+              type="submit"
+              className="btn btn-primary"
+              style={{ width: "100%", marginTop: "0.5rem" }}
+              disabled={submitting}
+            >
+              {submitting ? "ログイン中..." : "ログイン"}
+            </button>
+          </form>
+
+          <p style={{ marginTop: "1rem", textAlign: "center", fontSize: "0.875rem" }}>
+            アカウントをお持ちでない方は{" "}
+            <Link to="/register">新規登録</Link>
+          </p>
+        </div>
+      </main>
+    </>
+  );
+}
+
+export default Login;

--- a/frontapp-react/src/Register.jsx
+++ b/frontapp-react/src/Register.jsx
@@ -1,0 +1,93 @@
+import { useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import { BASE_URL } from "./utils/api";
+import { setToken } from "./utils/auth";
+import "./styles.css";
+
+function Register() {
+  const navigate = useNavigate();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError("");
+    setSubmitting(true);
+    try {
+      const res = await fetch(`${BASE_URL}/auth/register`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email, password }),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.detail || "登録に失敗しました");
+      }
+      const data = await res.json();
+      setToken(data.access_token);
+      navigate("/list");
+    } catch (e) {
+      setError(e.message);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <>
+      <header className="app-header">
+        <h1>メモアプリ</h1>
+      </header>
+
+      <main className="page">
+        <div className="form-card" style={{ maxWidth: 400, margin: "0 auto" }}>
+          <h2 className="page-title" style={{ marginBottom: "1.5rem" }}>新規登録</h2>
+
+          {error && <div className="alert-error" style={{ marginBottom: "1rem" }}>{error}</div>}
+
+          <form onSubmit={handleSubmit}>
+            <div className="form-group">
+              <label className="form-label">メールアドレス</label>
+              <input
+                className="form-input"
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                required
+                autoFocus
+              />
+            </div>
+            <div className="form-group">
+              <label className="form-label">パスワード（8文字以上）</label>
+              <input
+                className="form-input"
+                type="password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                required
+                minLength={8}
+              />
+            </div>
+            <button
+              type="submit"
+              className="btn btn-primary"
+              style={{ width: "100%", marginTop: "0.5rem" }}
+              disabled={submitting}
+            >
+              {submitting ? "登録中..." : "アカウントを作成"}
+            </button>
+          </form>
+
+          <p style={{ marginTop: "1rem", textAlign: "center", fontSize: "0.875rem" }}>
+            すでにアカウントをお持ちの方は{" "}
+            <Link to="/login">ログイン</Link>
+          </p>
+        </div>
+      </main>
+    </>
+  );
+}
+
+export default Register;

--- a/frontapp-react/src/components/Header.jsx
+++ b/frontapp-react/src/components/Header.jsx
@@ -1,0 +1,22 @@
+import { useNavigate } from "react-router-dom";
+import { removeToken } from "../utils/auth";
+
+function Header() {
+  const navigate = useNavigate();
+
+  const handleLogout = () => {
+    removeToken();
+    navigate("/login");
+  };
+
+  return (
+    <header className="app-header">
+      <h1>メモアプリ</h1>
+      <button className="btn btn-ghost btn-sm" onClick={handleLogout}>
+        ログアウト
+      </button>
+    </header>
+  );
+}
+
+export default Header;

--- a/frontapp-react/src/styles.css
+++ b/frontapp-react/src/styles.css
@@ -20,6 +20,7 @@ body {
   height: 56px;
   display: flex;
   align-items: center;
+  justify-content: space-between;
   box-shadow: 0 1px 4px rgba(0, 0, 0, 0.08);
   position: sticky;
   top: 0;

--- a/frontapp-react/src/utils/api.js
+++ b/frontapp-react/src/utils/api.js
@@ -1,1 +1,15 @@
 export const BASE_URL = process.env.REACT_APP_API_URL || "http://localhost:8000";
+
+export async function authFetch(url, options = {}) {
+  const token = localStorage.getItem("access_token");
+  const headers = {
+    ...(options.headers || {}),
+    ...(token ? { Authorization: `Bearer ${token}` } : {}),
+  };
+  const res = await fetch(url, { ...options, headers });
+  if (res.status === 401) {
+    localStorage.removeItem("access_token");
+    window.location.href = "/login";
+  }
+  return res;
+}

--- a/frontapp-react/src/utils/auth.js
+++ b/frontapp-react/src/utils/auth.js
@@ -1,0 +1,6 @@
+const TOKEN_KEY = "access_token";
+
+export const getToken = () => localStorage.getItem(TOKEN_KEY);
+export const setToken = (token) => localStorage.setItem(TOKEN_KEY, token);
+export const removeToken = () => localStorage.removeItem(TOKEN_KEY);
+export const isLoggedIn = () => Boolean(getToken());

--- a/main.py
+++ b/main.py
@@ -7,7 +7,9 @@ from sqlalchemy import text
 
 from db import engine, Base
 from routers.memo import router as memo_router
-import models.memo  # noqa: F401 - モデルを Base に登録するためにインポート
+from routers.auth import router as auth_router
+import models.memo  # noqa: F401
+import models.user  # noqa: F401
 
 
 @asynccontextmanager
@@ -42,6 +44,7 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+app.include_router(auth_router)
 app.include_router(memo_router)
 
 

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,3 +1,4 @@
 from .memo import Memo
+from .user import User
 
-__all__ = ["Memo"]
+__all__ = ["Memo", "User"]

--- a/models/memo.py
+++ b/models/memo.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, DateTime, Boolean
+from sqlalchemy import Column, Integer, String, DateTime, Boolean, ForeignKey
 from db import Base
 from datetime import datetime
 
@@ -18,6 +18,7 @@ class Memo(Base):
     __table_args__ = {"schema": "app"}
     # メモID：PK：自動インクリメント
     memo_id = Column(Integer, primary_key=True, autoincrement=True)
+    user_id = Column(Integer, ForeignKey("app.users.user_id"), nullable=False)
     # タイトル：未入力不可
     title = Column(String(50), nullable=False)
     # 詳細：未入力可

--- a/models/user.py
+++ b/models/user.py
@@ -1,0 +1,13 @@
+from sqlalchemy import Column, Integer, String, DateTime
+from datetime import datetime
+from db import Base
+
+
+class User(Base):
+    __tablename__ = "users"
+    __table_args__ = {"schema": "app"}
+
+    user_id = Column(Integer, primary_key=True, autoincrement=True)
+    email = Column(String(255), nullable=False, unique=True)
+    hashed_password = Column(String(255), nullable=False)
+    created_at = Column(DateTime, default=datetime.now)

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,8 @@ typing-inspection==0.4.1
 typing_extensions==4.14.1
 uvicorn==0.35.0
 asyncpg
+passlib[bcrypt]==1.7.4
+bcrypt==4.0.1
+python-jose[cryptography]==3.3.0
+python-multipart==0.0.9
+email-validator==2.2.0

--- a/routers/auth.py
+++ b/routers/auth.py
@@ -1,0 +1,43 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+import db
+import cruds.user as user_crud
+import schemas.user as user_schema
+from auth import verify_password, create_access_token, get_current_user
+import models.user as user_model
+
+router = APIRouter(tags=["Auth"], prefix="/auth")
+
+
+@router.post("/register", response_model=user_schema.TokenSchema, status_code=201)
+async def register(
+    data: user_schema.RegisterSchema,
+    session: AsyncSession = Depends(db.get_dbsession),
+):
+    existing = await user_crud.get_user_by_email(session, data.email)
+    if existing:
+        raise HTTPException(status_code=400, detail="このメールアドレスはすでに登録されています")
+
+    user = await user_crud.create_user(session, data)
+    token = create_access_token(user.user_id)
+    return user_schema.TokenSchema(access_token=token)
+
+
+@router.post("/login", response_model=user_schema.TokenSchema)
+async def login(
+    data: user_schema.LoginSchema,
+    session: AsyncSession = Depends(db.get_dbsession),
+):
+    user = await user_crud.get_user_by_email(session, data.email)
+    if not user or not verify_password(data.password, user.hashed_password):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="メールアドレスまたはパスワードが正しくありません",
+        )
+    token = create_access_token(user.user_id)
+    return user_schema.TokenSchema(access_token=token)
+
+
+@router.get("/me", response_model=user_schema.UserSchema)
+async def me(current_user: user_model.User = Depends(get_current_user)):
+    return user_schema.UserSchema(user_id=current_user.user_id, email=current_user.email)

--- a/routers/memo.py
+++ b/routers/memo.py
@@ -3,77 +3,81 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from schemas.memo import InsertAndUpdateMemoSchema, MemoSchema, ResponseSchema, MemoStatusSchema, PatchMemoSchema, to_memo_schema
 import cruds.memo as memo_crud
 import db
+from auth import get_current_user
+import models.user as user_model
 
-# ルーターを作成し、タグとURLパスのプレフィックスを設定
 router = APIRouter(tags=["Memos"], prefix="/memos")
 
-# ==================================================
-# メモ用のエンドポイント
-# ==================================================
-# メモ新規登録のエンドポイント
-@router.post("/", response_model=ResponseSchema)
-async def create_memo(memo: InsertAndUpdateMemoSchema,
-                    db: AsyncSession = Depends(db.get_dbsession)):
-    try:
-        # 新しいメモをデータベースに登録
-        await memo_crud.insert_memo(db, memo)
-        return ResponseSchema(message="メモが正常に登録されました")
-    except Exception as e:
-        # 登録に失敗した場合、HTTP 400エラーを返す
-        raise HTTPException(status_code=400, detail="メモの登録に失敗しました。")
 
-# メモ情報全件取得のエンドポイント
+@router.post("/", response_model=ResponseSchema, status_code=201)
+async def create_memo(
+    memo: InsertAndUpdateMemoSchema,
+    session: AsyncSession = Depends(db.get_dbsession),
+    current_user: user_model.User = Depends(get_current_user),
+):
+    try:
+        await memo_crud.insert_memo(session, memo, current_user.user_id)
+        return ResponseSchema(message="メモが正常に登録されました")
+    except Exception:
+        raise HTTPException(status_code=400, detail="メモの登録に失敗しました")
+
+
 @router.get("/", response_model=list[MemoSchema])
 async def get_memos_list(
     skip: int = 0,
     limit: int = 50,
-    db: AsyncSession = Depends(db.get_dbsession)
+    session: AsyncSession = Depends(db.get_dbsession),
+    current_user: user_model.User = Depends(get_current_user),
 ):
-    memos = await memo_crud.get_memos(db, skip=skip, limit=limit)
+    memos = await memo_crud.get_memos(session, current_user.user_id, skip=skip, limit=limit)
     return [to_memo_schema(memo) for memo in memos]
 
 
-# 特定のメモ情報取得のエンドポイント
 @router.get("/{memo_id}", response_model=MemoSchema)
-async def get_memo_detail(memo_id: int,
-                    db: AsyncSession = Depends(db.get_dbsession)):
-    # 指定されたIDのメモをデータベースから取得
-    memo = await memo_crud.get_memo_by_id(db, memo_id)
+async def get_memo_detail(
+    memo_id: int,
+    session: AsyncSession = Depends(db.get_dbsession),
+    current_user: user_model.User = Depends(get_current_user),
+):
+    memo = await memo_crud.get_memo_by_id(session, memo_id, current_user.user_id)
     if not memo:
-        # メモが見つからない場合、HTTP 404エラーを返す
         raise HTTPException(status_code=404, detail="メモが見つかりません")
     return to_memo_schema(memo)
 
-# 特定のメモを更新するエンドポイント
+
 @router.put("/{memo_id}", response_model=ResponseSchema)
-async def modify_memo(memo_id: int, memo: InsertAndUpdateMemoSchema,
-                    db: AsyncSession = Depends(db.get_dbsession)):
-    # 指定されたIDのメモを新しいデータで更新
-    updated_memo = await memo_crud.update_memo(db, memo_id, memo)
-    if not updated_memo:
-        # 更新対象が見つからない場合、HTTP 404エラーを返す
+async def modify_memo(
+    memo_id: int,
+    memo: InsertAndUpdateMemoSchema,
+    session: AsyncSession = Depends(db.get_dbsession),
+    current_user: user_model.User = Depends(get_current_user),
+):
+    updated = await memo_crud.update_memo(session, memo_id, memo, current_user.user_id)
+    if not updated:
         raise HTTPException(status_code=404, detail="更新対象が見つかりません")
     return ResponseSchema(message="メモが正常に更新されました")
 
-# 特定のメモを削除するエンドポイント
+
 @router.delete("/{memo_id}", response_model=ResponseSchema)
-async def remove_memo(memo_id: int,
-                    db: AsyncSession = Depends(db.get_dbsession)):
-    # 指定されたIDのメモをデータベースから削除
-    result = await memo_crud.delete_memo(db, memo_id)
+async def remove_memo(
+    memo_id: int,
+    session: AsyncSession = Depends(db.get_dbsession),
+    current_user: user_model.User = Depends(get_current_user),
+):
+    result = await memo_crud.delete_memo(session, memo_id, current_user.user_id)
     if not result:
-        # 削除対象が見つからない場合、HTTP 404エラーを返す
         raise HTTPException(status_code=404, detail="削除対象が見つかりません")
     return ResponseSchema(message="メモが正常に削除されました")
+
 
 @router.patch("/{memo_id}", response_model=ResponseSchema)
 async def toggle_memo_completed(
     memo_id: int,
     body: PatchMemoSchema,
-    db: AsyncSession = Depends(db.get_dbsession)
+    session: AsyncSession = Depends(db.get_dbsession),
+    current_user: user_model.User = Depends(get_current_user),
 ):
-    updated = await memo_crud.patch_memo(db, memo_id, {"is_completed": body.is_completed})
+    updated = await memo_crud.patch_memo(session, memo_id, {"is_completed": body.is_completed}, current_user.user_id)
     if not updated:
         raise HTTPException(status_code=404, detail="対象メモが見つかりません")
-
     return ResponseSchema(message="完了状態を更新しました")

--- a/schemas/user.py
+++ b/schemas/user.py
@@ -1,0 +1,21 @@
+from pydantic import BaseModel, Field, EmailStr
+
+
+class RegisterSchema(BaseModel):
+    email: EmailStr
+    password: str = Field(..., min_length=8)
+
+
+class LoginSchema(BaseModel):
+    email: EmailStr
+    password: str
+
+
+class TokenSchema(BaseModel):
+    access_token: str
+    token_type: str = "bearer"
+
+
+class UserSchema(BaseModel):
+    user_id: int
+    email: str


### PR DESCRIPTION
## Summary

- **バックエンド**: User モデル・CRUD・ルーターを追加し `/auth/register`, `/auth/login`, `/auth/me` を実装。JWT トークン発行 (python-jose) と bcrypt パスワードハッシュ (passlib) を使用。メモ全エンドポイントを認証必須化し、ユーザーごとにデータを分離
- **フロントエンド**: Login / Register ページを新規作成。`authFetch` で Authorization ヘッダーを自動付与し、401 時は `/login` にリダイレクト。`PrivateRoute` / `PublicOnlyRoute` でルートを保護。共通 `Header` コンポーネントにログアウトボタンを追加
- **インフラ**: `docker-compose.yml` に `SECRET_KEY` 環境変数を追加。`requirements.txt` に認証関連パッケージを追加 (`passlib[bcrypt]`, `python-jose`, `email-validator`, `bcrypt==4.0.1`)

## Test plan

- [ ] `http://localhost:3000` にアクセスすると未ログイン時は `/login` にリダイレクトされること
- [ ] 新規登録 (`/register`) でアカウントを作成し、メモ一覧に遷移すること
- [ ] ログイン (`/login`) 後にメモ一覧が表示されること
- [ ] ログアウトボタン押下でトークンが削除され `/login` に遷移すること
- [ ] 異なるユーザーのメモが見えないこと (ユーザー分離)
- [ ] トークンなしで `/memos/` にアクセスすると 401 が返ること

