### PR TITLE
chore: ECSデプロイ用ファイルを追加

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -e
+
+IMAGE=632752099901.dkr.ecr.ap-northeast-1.amazonaws.com/memo-fastapi-dev:latest
+
+echo "🚀 build..."
+docker build -t memo-fastapi-dev .
+
+echo "🏷 tag..."
+docker tag memo-fastapi-dev:latest $IMAGE
+
+echo "📦 push..."
+docker push $IMAGE
+
+echo "🔄 deploy..."
+aws ecs update-service \
+  --cluster memo-fastapi-cluster \
+  --service memo-fastapi-service \
+  --force-new-deployment
+
+echo "✅ done"

--- a/frontapp-react/Dockerfile
+++ b/frontapp-react/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:20
+
+WORKDIR /app
+
+COPY package*.json ./
+
+RUN npm install
+
+COPY . .
+
+EXPOSE 3000
+
+CMD ["npm", "start"]

--- a/task-definition.json
+++ b/task-definition.json
@@ -1,0 +1,29 @@
+{
+  "family": "memo-fastapi-task",
+  "networkMode": "awsvpc",
+  "requiresCompatibilities": ["FARGATE"],
+  "cpu": "512",
+  "memory": "1024",
+  "executionRoleArn": "arn:aws:iam::632752099901:role/ecsTaskExecutionRole",
+  "containerDefinitions": [
+    {
+      "name": "memo-fastapi",
+      "image": "632752099901.dkr.ecr.ap-northeast-1.amazonaws.com/memo-fastapi-dev:latest",
+      "portMappings": [
+        {
+          "containerPort": 8000,
+          "protocol": "tcp"
+        }
+      ],
+      "essential": true,
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "/ecs/memo-fastapi",
+          "awslogs-region": "ap-northeast-1",
+          "awslogs-stream-prefix": "ecs"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- `deploy.sh`: ECR へのイメージビルド・タグ付け・プッシュと ECS サービスの強制再デプロイを行うスクリプト
- `task-definition.json`: ECS Fargate タスク定義 (512CPU / 1024MB, ap-northeast-1, CloudWatch Logs 設定済み)
- `frontapp-react/Dockerfile`: フロントエンド用 Node.js 20 ベースの Dockerfile

## Test plan

- [ ] `deploy.sh` を実行して ECR へのプッシュと ECS デプロイが成功すること
- [ ] `task-definition.json` を `aws ecs register-task-definition` で登録できること

