### PR TITLE
chore: 機密情報を .env で管理・DBヘルスチェックを追加

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,15 @@
-# DB 接続文字列
-# Docker Compose 経由の場合は db（サービス名）を指定
-DATABASE_URL=postgresql+asyncpg://fastapi_user:your_password@localhost:5432/fastapi_db
+# PostgreSQL
+POSTGRES_USER=fastapi_user
+POSTGRES_PASSWORD=your_password
+POSTGRES_DB=fastapi_db
+
+# バックエンド
+# Docker Compose 経由の場合はホスト名を db（サービス名）にする
+DATABASE_URL=postgresql+asyncpg://fastapi_user:your_password@db:5432/fastapi_db
+
+# JWT 署名キー（本番では必ず強力なランダム文字列に変更すること）
+# 生成例: python3 -c "import secrets; print(secrets.token_hex(32))"
+SECRET_KEY=change-me-in-production
 
 # フロントエンドから叩く API の URL（省略時は http://localhost:8000）
 # REACT_APP_API_URL=http://localhost:8000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,12 +4,14 @@ services:
   db:
     image: postgres
     container_name: postgres
-    environment:
-      POSTGRES_USER: fastapi_user
-      POSTGRES_PASSWORD: kh817012
-      POSTGRES_DB: fastapi_db
+    env_file: .env
     ports:
       - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
 
   backend:
     build: .
@@ -17,10 +19,9 @@ services:
     ports:
       - "8000:8000"
     depends_on:
-      - db
-    environment:
-      DATABASE_URL: postgresql+asyncpg://fastapi_user:kh817012@db:5432/fastapi_db
-      SECRET_KEY: change-me-in-production
+      db:
+        condition: service_healthy
+    env_file: .env
   frontend:
     build:
       context: ./frontapp-react


### PR DESCRIPTION
## Summary

- `docker-compose.yml` にハードコードされていた DB パスワード・`SECRET_KEY` を `env_file: .env` 参照に変更。`.env` は `.gitignore` 済みなので Git に上がらない
- `db` サービスに `healthcheck` を追加し、PostgreSQL が完全に起動してから `backend` が接続するよう `depends_on` に `condition: service_healthy` を設定（起動タイミングの競合を解消）
- `.env.example` に `POSTGRES_USER` / `POSTGRES_PASSWORD` / `POSTGRES_DB` / `SECRET_KEY` を追加し、新規セットアップ手順を明確化

## セットアップ手順（README 更新候補）

```bash
cp .env.example .env
# .env を編集して実際の値を設定
docker compose up -d
```

## Test plan

- [ ] `.env` を用意して `docker compose up -d` が正常起動すること
- [ ] `docker compose ps` で全コンテナが `Up` になること
- [ ] `http://localhost:8000/` が `{"message":"FastAPI is running"}` を返すこと
- [ ] `.env` が Git に含まれていないこと (`git status` で Untracked のまま)

