### PR TITLE
feat: メモの検索・フィルター機能を追加

### DIFF
--- a/cruds/memo.py
+++ b/cruds/memo.py
@@ -28,13 +28,21 @@ async def get_memos(
     user_id: int,
     skip: int = 0,
     limit: int = 50,
+    search: str | None = None,
+    priority: str | None = None,
+    is_completed: bool | None = None,
 ) -> list[memo_model.Memo]:
-    result = await session.execute(
+    query = (
         select(memo_model.Memo)
         .where(memo_model.Memo.user_id == user_id)
-        .offset(skip)
-        .limit(limit)
     )
+    if search:
+        query = query.where(memo_model.Memo.title.ilike(f"%{search}%"))
+    if priority:
+        query = query.where(memo_model.Memo.priority == priority)
+    if is_completed is not None:
+        query = query.where(memo_model.Memo.is_completed == is_completed)
+    result = await session.execute(query.offset(skip).limit(limit))
     return result.scalars().all()
 
 

--- a/frontapp-react/src/ListMemos.jsx
+++ b/frontapp-react/src/ListMemos.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, useCallback } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import "./styles.css";
 import { BASE_URL, authFetch } from "./utils/api";
@@ -23,6 +23,15 @@ function priorityBadge(priority) {
   return map[priority] ?? "badge badge-low";
 }
 
+function buildQuery(search, priority, isCompleted) {
+  const params = new URLSearchParams();
+  if (search) params.set("search", search);
+  if (priority) params.set("priority", priority);
+  if (isCompleted !== "") params.set("is_completed", isCompleted);
+  const qs = params.toString();
+  return qs ? `?${qs}` : "";
+}
+
 function ListMemos() {
   const navigate = useNavigate();
   const [memos, setMemos] = useState([]);
@@ -30,23 +39,35 @@ function ListMemos() {
   const [error, setError] = useState("");
   const [successMsg, setSuccessMsg] = useState("");
 
-  useEffect(() => {
-    const fetchMemos = async () => {
-      try {
-        setLoading(true);
-        setError("");
-        const res = await authFetch(`${BASE_URL}/memos/`);
-        if (!res.ok) throw new Error(`取得失敗 (status: ${res.status})`);
-        const data = await res.json();
-        setMemos(Array.isArray(data) ? data : []);
-      } catch (e) {
-        setError(e.message || "一覧取得に失敗しました");
-      } finally {
-        setLoading(false);
-      }
-    };
-    fetchMemos();
+  const [searchInput, setSearchInput] = useState("");
+  const [search, setSearch] = useState("");
+  const [priority, setPriority] = useState("");
+  const [isCompleted, setIsCompleted] = useState("");
+
+  const fetchMemos = useCallback(async (s, p, c) => {
+    try {
+      setLoading(true);
+      setError("");
+      const qs = buildQuery(s, p, c);
+      const res = await authFetch(`${BASE_URL}/memos/${qs}`);
+      if (!res.ok) throw new Error(`取得失敗 (status: ${res.status})`);
+      const data = await res.json();
+      setMemos(Array.isArray(data) ? data : []);
+    } catch (e) {
+      setError(e.message || "一覧取得に失敗しました");
+    } finally {
+      setLoading(false);
+    }
   }, []);
+
+  useEffect(() => {
+    fetchMemos(search, priority, isCompleted);
+  }, [search, priority, isCompleted, fetchMemos]);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setSearch(searchInput), 300);
+    return () => clearTimeout(timer);
+  }, [searchInput]);
 
   const handleDelete = async (id) => {
     if (!window.confirm("本当に削除しますか？")) return;
@@ -61,12 +82,7 @@ function ListMemos() {
     }
   };
 
-  if (loading) return (
-    <>
-      <Header />
-      <div className="page"><p>読み込み中...</p></div>
-    </>
-  );
+  const hasFilter = searchInput || priority || isCompleted !== "";
 
   return (
     <>
@@ -78,32 +94,82 @@ function ListMemos() {
           <Link to="/create" className="btn btn-primary">+ 新規作成</Link>
         </div>
 
+        <div className="filter-bar">
+          <input
+            className="form-input filter-search"
+            type="text"
+            placeholder="タイトルで検索..."
+            value={searchInput}
+            onChange={(e) => setSearchInput(e.target.value)}
+          />
+          <select
+            className="form-select filter-select"
+            value={priority}
+            onChange={(e) => setPriority(e.target.value)}
+          >
+            <option value="">優先度: 全て</option>
+            <option value="高">高</option>
+            <option value="中">中</option>
+            <option value="低">低</option>
+          </select>
+          <select
+            className="form-select filter-select"
+            value={isCompleted}
+            onChange={(e) => setIsCompleted(e.target.value)}
+          >
+            <option value="">状態: 全て</option>
+            <option value="false">未完</option>
+            <option value="true">完了</option>
+          </select>
+          {hasFilter && (
+            <button
+              className="btn btn-ghost btn-sm"
+              onClick={() => {
+                setSearchInput("");
+                setSearch("");
+                setPriority("");
+                setIsCompleted("");
+              }}
+            >
+              リセット
+            </button>
+          )}
+        </div>
+
         {error && <div className="alert-error">{error}</div>}
         {successMsg && <div className="alert-success">{successMsg}</div>}
 
-        {memos.length === 0 ? (
+        {loading ? (
+          <p style={{ color: "#9ca3af", padding: "20px 0" }}>読み込み中...</p>
+        ) : memos.length === 0 ? (
           <div className="empty-state">
-            <p>まだメモがありません</p>
-            <Link to="/create" className="btn btn-primary">最初のメモを作成する</Link>
+            {hasFilter ? (
+              <p>条件に一致するメモがありません</p>
+            ) : (
+              <>
+                <p>まだメモがありません</p>
+                <Link to="/create" className="btn btn-primary">最初のメモを作成する</Link>
+              </>
+            )}
           </div>
         ) : (
           <ul className="memo-list">
             {memos.map((m) => {
               const status = m.status ?? {};
-              const isCompleted = Boolean(status.is_completed);
+              const completed = Boolean(status.is_completed);
               const dueDate = status.due_date ? formatDate(status.due_date) : null;
               const createdAt = formatDate(m.created_at);
 
               return (
-                <li key={m.memo_id} className={`memo-card${isCompleted ? " completed" : ""}`}>
+                <li key={m.memo_id} className={`memo-card${completed ? " completed" : ""}`}>
                   <div className="memo-card-top">
                     <span className="memo-title">{m.title}</span>
                     <div className="memo-badges">
                       <span className={priorityBadge(status.priority)}>
                         {status.priority ?? "-"}
                       </span>
-                      <span className={isCompleted ? "badge badge-done" : "badge badge-pending"}>
-                        {isCompleted ? "完了" : "未完"}
+                      <span className={completed ? "badge badge-done" : "badge badge-pending"}>
+                        {completed ? "完了" : "未完"}
                       </span>
                     </div>
                   </div>

--- a/frontapp-react/src/styles.css
+++ b/frontapp-react/src/styles.css
@@ -129,6 +129,25 @@ body {
   transform: none;
 }
 
+/* ===== フィルターバー ===== */
+.filter-bar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-bottom: 20px;
+}
+
+.filter-search {
+  flex: 1;
+  min-width: 180px;
+}
+
+.filter-select {
+  width: auto;
+  min-width: 120px;
+}
+
 /* ===== メモカード ===== */
 .memo-list {
   display: flex;

--- a/routers/memo.py
+++ b/routers/memo.py
@@ -26,10 +26,17 @@ async def create_memo(
 async def get_memos_list(
     skip: int = 0,
     limit: int = 50,
+    search: str | None = None,
+    priority: str | None = None,
+    is_completed: bool | None = None,
     session: AsyncSession = Depends(db.get_dbsession),
     current_user: user_model.User = Depends(get_current_user),
 ):
-    memos = await memo_crud.get_memos(session, current_user.user_id, skip=skip, limit=limit)
+    memos = await memo_crud.get_memos(
+        session, current_user.user_id,
+        skip=skip, limit=limit,
+        search=search, priority=priority, is_completed=is_completed,
+    )
     return [to_memo_schema(memo) for memo in memos]
 
 


### PR DESCRIPTION
## Summary

- **バックエンド**: `GET /memos/` に `search`（タイトル部分一致・大文字小文字無視）・`priority`（高/中/低）・`is_completed`（true/false）クエリパラメータを追加。SQLAlchemy の動的クエリ条件で実装
- **フロントエンド**: メモ一覧上部にフィルターバーを追加。検索は 300ms デバウンスでAPIを叩くため入力が軽快。フィルター適用中は「リセット」ボタンが表示され、ワンクリックで全条件をクリア。フィルター結果0件時は「条件に一致するメモがありません」を表示

## 動作確認済みパターン

| パラメータ | 例 | 動作 |
|-----------|-----|------|
| `search=高` | `?search=高` | タイトルに「高」を含むメモのみ |
| `priority=低` | `?priority=低` | 優先度「低」のメモのみ |
| `is_completed=true` | `?is_completed=true` | 完了済みメモのみ |
| 組み合わせ | `?priority=高&is_completed=false` | AND 条件で絞り込み |

## Test plan

- [ ] 検索バーに入力すると 300ms 後にフィルタリングされること
- [ ] 優先度ドロップダウンで絞り込みできること
- [ ] 完了状態ドロップダウンで絞り込みできること
- [ ] 複数フィルターを組み合わせて AND 条件で絞り込みできること
- [ ] フィルター適用中に「リセット」ボタンが表示され、クリックで全条件がクリアされること
- [ ] 結果0件時に「条件に一致するメモがありません」が表示されること

