### PR TITLE
feat: 請求書管理バックエンドを追加

### DIFF
--- a/cruds/invoice.py
+++ b/cruds/invoice.py
@@ -1,0 +1,220 @@
+from decimal import Decimal
+from sqlalchemy import select, func
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+import models.invoice as m
+import schemas.invoice as s
+
+
+# ===== 請求書番号の自動採番 =====
+
+async def generate_invoice_number(session: AsyncSession, user_id: int) -> str:
+    result = await session.execute(
+        select(func.count()).where(m.Invoice.user_id == user_id)
+    )
+    count = result.scalar() + 1
+    from datetime import datetime
+    ym = datetime.now().strftime("%Y%m")
+    return f"INV-{ym}-{count:04d}"
+
+
+# ===== 金額計算ヘルパー =====
+
+def calc_item(item: m.InvoiceItem) -> dict:
+    subtotal = Decimal(str(item.unit_price)) * item.quantity
+    tax_amount = (subtotal * Decimal(str(item.tax_rate))).quantize(Decimal("1"))
+    return {
+        "subtotal": subtotal,
+        "tax_amount": tax_amount,
+        "total": subtotal + tax_amount,
+    }
+
+
+# ===== Client =====
+
+async def create_client(session: AsyncSession, data: s.ClientCreateSchema, user_id: int) -> m.Client:
+    client = m.Client(user_id=user_id, **data.model_dump())
+    session.add(client)
+    await session.commit()
+    await session.refresh(client)
+    return client
+
+
+async def get_clients(session: AsyncSession, user_id: int) -> list[m.Client]:
+    result = await session.execute(
+        select(m.Client).where(m.Client.user_id == user_id).order_by(m.Client.name)
+    )
+    return result.scalars().all()
+
+
+async def get_client(session: AsyncSession, client_id: int, user_id: int) -> m.Client | None:
+    result = await session.execute(
+        select(m.Client).where(m.Client.client_id == client_id, m.Client.user_id == user_id)
+    )
+    return result.scalars().first()
+
+
+async def update_client(session: AsyncSession, client_id: int, data: s.ClientCreateSchema, user_id: int) -> m.Client | None:
+    client = await get_client(session, client_id, user_id)
+    if not client:
+        return None
+    for k, v in data.model_dump().items():
+        setattr(client, k, v)
+    await session.commit()
+    await session.refresh(client)
+    return client
+
+
+async def delete_client(session: AsyncSession, client_id: int, user_id: int) -> m.Client | None:
+    client = await get_client(session, client_id, user_id)
+    if client:
+        await session.delete(client)
+        await session.commit()
+    return client
+
+
+# ===== InvoiceItemTemplate =====
+
+async def create_template(session: AsyncSession, data: s.ItemTemplateCreateSchema, user_id: int) -> m.InvoiceItemTemplate:
+    tmpl = m.InvoiceItemTemplate(user_id=user_id, **data.model_dump())
+    session.add(tmpl)
+    await session.commit()
+    await session.refresh(tmpl)
+    return tmpl
+
+
+async def get_templates(session: AsyncSession, user_id: int) -> list[m.InvoiceItemTemplate]:
+    result = await session.execute(
+        select(m.InvoiceItemTemplate).where(m.InvoiceItemTemplate.user_id == user_id)
+    )
+    return result.scalars().all()
+
+
+async def delete_template(session: AsyncSession, template_id: int, user_id: int) -> m.InvoiceItemTemplate | None:
+    result = await session.execute(
+        select(m.InvoiceItemTemplate).where(
+            m.InvoiceItemTemplate.template_id == template_id,
+            m.InvoiceItemTemplate.user_id == user_id,
+        )
+    )
+    tmpl = result.scalars().first()
+    if tmpl:
+        await session.delete(tmpl)
+        await session.commit()
+    return tmpl
+
+
+# ===== Invoice =====
+
+async def create_invoice(session: AsyncSession, data: s.InvoiceCreateSchema, user_id: int) -> m.Invoice:
+    invoice_number = await generate_invoice_number(session, user_id)
+    invoice = m.Invoice(
+        user_id=user_id,
+        client_id=data.client_id,
+        invoice_number=invoice_number,
+        issued_at=data.issued_at,
+        due_at=data.due_at,
+        notes=data.notes,
+        status="unpaid",
+    )
+    session.add(invoice)
+    await session.flush()
+
+    for item_data in data.items:
+        item = m.InvoiceItem(invoice_id=invoice.invoice_id, **item_data.model_dump())
+        session.add(item)
+
+    await session.commit()
+    await session.refresh(invoice)
+    return invoice
+
+
+async def get_invoices(
+    session: AsyncSession,
+    user_id: int,
+    status: str | None = None,
+    client_id: int | None = None,
+) -> list[m.Invoice]:
+    query = (
+        select(m.Invoice)
+        .options(selectinload(m.Invoice.client), selectinload(m.Invoice.items))
+        .where(m.Invoice.user_id == user_id)
+    )
+    if status:
+        query = query.where(m.Invoice.status == status)
+    if client_id:
+        query = query.where(m.Invoice.client_id == client_id)
+    query = query.order_by(m.Invoice.issued_at.desc())
+    result = await session.execute(query)
+    return result.scalars().all()
+
+
+async def get_invoice(session: AsyncSession, invoice_id: int, user_id: int) -> m.Invoice | None:
+    result = await session.execute(
+        select(m.Invoice)
+        .options(selectinload(m.Invoice.client), selectinload(m.Invoice.items))
+        .where(m.Invoice.invoice_id == invoice_id, m.Invoice.user_id == user_id)
+    )
+    return result.scalars().first()
+
+
+async def update_invoice(session: AsyncSession, invoice_id: int, data: s.InvoiceUpdateSchema, user_id: int) -> m.Invoice | None:
+    invoice = await get_invoice(session, invoice_id, user_id)
+    if not invoice:
+        return None
+    invoice.client_id = data.client_id
+    invoice.issued_at = data.issued_at
+    invoice.due_at = data.due_at
+    invoice.notes = data.notes
+
+    for item in invoice.items:
+        await session.delete(item)
+    await session.flush()
+
+    for item_data in data.items:
+        item = m.InvoiceItem(invoice_id=invoice.invoice_id, **item_data.model_dump())
+        session.add(item)
+
+    await session.commit()
+    await session.refresh(invoice)
+    return invoice
+
+
+async def patch_invoice_status(session: AsyncSession, invoice_id: int, status: str, user_id: int) -> m.Invoice | None:
+    invoice = await get_invoice(session, invoice_id, user_id)
+    if not invoice:
+        return None
+    invoice.status = status
+    await session.commit()
+    await session.refresh(invoice)
+    return invoice
+
+
+async def delete_invoice(session: AsyncSession, invoice_id: int, user_id: int) -> m.Invoice | None:
+    invoice = await get_invoice(session, invoice_id, user_id)
+    if invoice:
+        await session.delete(invoice)
+        await session.commit()
+    return invoice
+
+
+# ===== Profile =====
+
+async def get_profile(session: AsyncSession, user_id: int) -> m.Profile | None:
+    result = await session.execute(
+        select(m.Profile).where(m.Profile.user_id == user_id)
+    )
+    return result.scalars().first()
+
+
+async def upsert_profile(session: AsyncSession, data: s.ProfileCreateSchema, user_id: int) -> m.Profile:
+    profile = await get_profile(session, user_id)
+    if profile:
+        for k, v in data.model_dump().items():
+            setattr(profile, k, v)
+    else:
+        profile = m.Profile(user_id=user_id, **data.model_dump())
+        session.add(profile)
+    await session.commit()
+    await session.refresh(profile)
+    return profile

--- a/main.py
+++ b/main.py
@@ -8,8 +8,10 @@ from sqlalchemy import text
 from db import engine, Base
 from routers.memo import router as memo_router
 from routers.auth import router as auth_router
+from routers.invoice import router as invoice_router
 import models.memo  # noqa: F401
 import models.user  # noqa: F401
+import models.invoice  # noqa: F401
 
 
 @asynccontextmanager
@@ -46,6 +48,7 @@ app.add_middleware(
 
 app.include_router(auth_router)
 app.include_router(memo_router)
+app.include_router(invoice_router)
 
 
 @app.exception_handler(ValidationError)

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,4 +1,5 @@
 from .memo import Memo
 from .user import User
+from .invoice import Client, InvoiceItemTemplate, Invoice, InvoiceItem, Profile
 
-__all__ = ["Memo", "User"]
+__all__ = ["Memo", "User", "Client", "InvoiceItemTemplate", "Invoice", "InvoiceItem", "Profile"]

--- a/models/invoice.py
+++ b/models/invoice.py
@@ -1,0 +1,81 @@
+from sqlalchemy import Column, Integer, String, DateTime, Numeric, ForeignKey, Text, Enum
+from sqlalchemy.orm import relationship
+from datetime import datetime
+from db import Base
+import enum
+
+
+class InvoiceStatus(str, enum.Enum):
+    unpaid = "unpaid"
+    paid = "paid"
+
+
+class Client(Base):
+    __tablename__ = "clients"
+    __table_args__ = {"schema": "app"}
+
+    client_id = Column(Integer, primary_key=True, autoincrement=True)
+    user_id = Column(Integer, ForeignKey("app.users.user_id"), nullable=False)
+    name = Column(String(100), nullable=False)
+    contact_name = Column(String(100))
+    address = Column(String(255))
+    email = Column(String(255))
+    created_at = Column(DateTime, default=datetime.now)
+
+    invoices = relationship("Invoice", back_populates="client")
+
+
+class InvoiceItemTemplate(Base):
+    __tablename__ = "invoice_item_templates"
+    __table_args__ = {"schema": "app"}
+
+    template_id = Column(Integer, primary_key=True, autoincrement=True)
+    user_id = Column(Integer, ForeignKey("app.users.user_id"), nullable=False)
+    name = Column(String(100), nullable=False)
+    unit_price = Column(Numeric(12, 0), nullable=False)
+    tax_rate = Column(Numeric(4, 2), nullable=False, default=0.10)
+
+
+class Invoice(Base):
+    __tablename__ = "invoices"
+    __table_args__ = {"schema": "app"}
+
+    invoice_id = Column(Integer, primary_key=True, autoincrement=True)
+    user_id = Column(Integer, ForeignKey("app.users.user_id"), nullable=False)
+    client_id = Column(Integer, ForeignKey("app.clients.client_id"), nullable=False)
+    invoice_number = Column(String(20), nullable=False)
+    issued_at = Column(DateTime, nullable=False)
+    due_at = Column(DateTime, nullable=False)
+    status = Column(String(10), nullable=False, default=InvoiceStatus.unpaid)
+    notes = Column(Text)
+    created_at = Column(DateTime, default=datetime.now)
+
+    client = relationship("Client", back_populates="invoices")
+    items = relationship("InvoiceItem", back_populates="invoice", cascade="all, delete-orphan")
+
+
+class InvoiceItem(Base):
+    __tablename__ = "invoice_items"
+    __table_args__ = {"schema": "app"}
+
+    item_id = Column(Integer, primary_key=True, autoincrement=True)
+    invoice_id = Column(Integer, ForeignKey("app.invoices.invoice_id"), nullable=False)
+    name = Column(String(100), nullable=False)
+    quantity = Column(Integer, nullable=False, default=1)
+    unit_price = Column(Numeric(12, 0), nullable=False)
+    tax_rate = Column(Numeric(4, 2), nullable=False, default=0.10)
+
+    invoice = relationship("Invoice", back_populates="items")
+
+
+class Profile(Base):
+    __tablename__ = "profiles"
+    __table_args__ = {"schema": "app"}
+
+    profile_id = Column(Integer, primary_key=True, autoincrement=True)
+    user_id = Column(Integer, ForeignKey("app.users.user_id"), nullable=False, unique=True)
+    display_name = Column(String(100), nullable=False)
+    company_name = Column(String(100))
+    address = Column(String(255))
+    phone = Column(String(20))
+    bank_info = Column(Text)

--- a/routers/invoice.py
+++ b/routers/invoice.py
@@ -1,0 +1,231 @@
+from decimal import Decimal
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+import db
+import cruds.invoice as crud
+import schemas.invoice as s
+from auth import get_current_user
+import models.user as user_model
+import models.invoice as m
+
+router = APIRouter(tags=["Invoices"], prefix="/invoices")
+
+
+# ===== 変換ヘルパー =====
+
+def to_item_schema(item: m.InvoiceItem) -> s.InvoiceItemSchema:
+    subtotal = Decimal(str(item.unit_price)) * item.quantity
+    tax_amount = (subtotal * Decimal(str(item.tax_rate))).quantize(Decimal("1"))
+    return s.InvoiceItemSchema(
+        item_id=item.item_id,
+        name=item.name,
+        quantity=item.quantity,
+        unit_price=Decimal(str(item.unit_price)),
+        tax_rate=Decimal(str(item.tax_rate)),
+        subtotal=subtotal,
+        tax_amount=tax_amount,
+        total=subtotal + tax_amount,
+    )
+
+
+def to_invoice_schema(invoice: m.Invoice) -> s.InvoiceSchema:
+    items = [to_item_schema(i) for i in invoice.items]
+    subtotal = sum(i.subtotal for i in items)
+    tax_amount = sum(i.tax_amount for i in items)
+    return s.InvoiceSchema(
+        invoice_id=invoice.invoice_id,
+        invoice_number=invoice.invoice_number,
+        client_id=invoice.client_id,
+        client_name=invoice.client.name,
+        issued_at=invoice.issued_at,
+        due_at=invoice.due_at,
+        status=invoice.status,
+        notes=invoice.notes,
+        items=items,
+        subtotal=subtotal,
+        tax_amount=tax_amount,
+        total=subtotal + tax_amount,
+        created_at=invoice.created_at,
+    )
+
+
+def to_invoice_list_schema(invoice: m.Invoice) -> s.InvoiceListSchema:
+    items = [to_item_schema(i) for i in invoice.items]
+    total = sum(i.total for i in items)
+    return s.InvoiceListSchema(
+        invoice_id=invoice.invoice_id,
+        invoice_number=invoice.invoice_number,
+        client_name=invoice.client.name,
+        issued_at=invoice.issued_at,
+        due_at=invoice.due_at,
+        status=invoice.status,
+        total=total,
+        created_at=invoice.created_at,
+    )
+
+
+# ===== 取引先 =====
+
+@router.get("/clients", response_model=list[s.ClientSchema])
+async def list_clients(
+    session: AsyncSession = Depends(db.get_dbsession),
+    current_user: user_model.User = Depends(get_current_user),
+):
+    return await crud.get_clients(session, current_user.user_id)
+
+
+@router.post("/clients", response_model=s.ClientSchema, status_code=201)
+async def create_client(
+    data: s.ClientCreateSchema,
+    session: AsyncSession = Depends(db.get_dbsession),
+    current_user: user_model.User = Depends(get_current_user),
+):
+    return await crud.create_client(session, data, current_user.user_id)
+
+
+@router.put("/clients/{client_id}", response_model=s.ClientSchema)
+async def update_client(
+    client_id: int,
+    data: s.ClientCreateSchema,
+    session: AsyncSession = Depends(db.get_dbsession),
+    current_user: user_model.User = Depends(get_current_user),
+):
+    client = await crud.update_client(session, client_id, data, current_user.user_id)
+    if not client:
+        raise HTTPException(status_code=404, detail="取引先が見つかりません")
+    return client
+
+
+@router.delete("/clients/{client_id}", status_code=204)
+async def delete_client(
+    client_id: int,
+    session: AsyncSession = Depends(db.get_dbsession),
+    current_user: user_model.User = Depends(get_current_user),
+):
+    result = await crud.delete_client(session, client_id, current_user.user_id)
+    if not result:
+        raise HTTPException(status_code=404, detail="取引先が見つかりません")
+
+
+# ===== 品目テンプレート =====
+
+@router.get("/templates", response_model=list[s.ItemTemplateSchema])
+async def list_templates(
+    session: AsyncSession = Depends(db.get_dbsession),
+    current_user: user_model.User = Depends(get_current_user),
+):
+    return await crud.get_templates(session, current_user.user_id)
+
+
+@router.post("/templates", response_model=s.ItemTemplateSchema, status_code=201)
+async def create_template(
+    data: s.ItemTemplateCreateSchema,
+    session: AsyncSession = Depends(db.get_dbsession),
+    current_user: user_model.User = Depends(get_current_user),
+):
+    return await crud.create_template(session, data, current_user.user_id)
+
+
+@router.delete("/templates/{template_id}", status_code=204)
+async def delete_template(
+    template_id: int,
+    session: AsyncSession = Depends(db.get_dbsession),
+    current_user: user_model.User = Depends(get_current_user),
+):
+    result = await crud.delete_template(session, template_id, current_user.user_id)
+    if not result:
+        raise HTTPException(status_code=404, detail="テンプレートが見つかりません")
+
+
+# ===== 請求書 =====
+
+@router.get("/", response_model=list[s.InvoiceListSchema])
+async def list_invoices(
+    status: str | None = None,
+    client_id: int | None = None,
+    session: AsyncSession = Depends(db.get_dbsession),
+    current_user: user_model.User = Depends(get_current_user),
+):
+    invoices = await crud.get_invoices(session, current_user.user_id, status=status, client_id=client_id)
+    return [to_invoice_list_schema(inv) for inv in invoices]
+
+
+@router.post("/", response_model=s.InvoiceSchema, status_code=201)
+async def create_invoice(
+    data: s.InvoiceCreateSchema,
+    session: AsyncSession = Depends(db.get_dbsession),
+    current_user: user_model.User = Depends(get_current_user),
+):
+    invoice = await crud.create_invoice(session, data, current_user.user_id)
+    invoice = await crud.get_invoice(session, invoice.invoice_id, current_user.user_id)
+    return to_invoice_schema(invoice)
+
+
+@router.get("/{invoice_id}", response_model=s.InvoiceSchema)
+async def get_invoice(
+    invoice_id: int,
+    session: AsyncSession = Depends(db.get_dbsession),
+    current_user: user_model.User = Depends(get_current_user),
+):
+    invoice = await crud.get_invoice(session, invoice_id, current_user.user_id)
+    if not invoice:
+        raise HTTPException(status_code=404, detail="請求書が見つかりません")
+    return to_invoice_schema(invoice)
+
+
+@router.put("/{invoice_id}", response_model=s.InvoiceSchema)
+async def update_invoice(
+    invoice_id: int,
+    data: s.InvoiceUpdateSchema,
+    session: AsyncSession = Depends(db.get_dbsession),
+    current_user: user_model.User = Depends(get_current_user),
+):
+    invoice = await crud.update_invoice(session, invoice_id, data, current_user.user_id)
+    if not invoice:
+        raise HTTPException(status_code=404, detail="請求書が見つかりません")
+    invoice = await crud.get_invoice(session, invoice_id, current_user.user_id)
+    return to_invoice_schema(invoice)
+
+
+@router.patch("/{invoice_id}/status", response_model=s.InvoiceSchema)
+async def patch_status(
+    invoice_id: int,
+    data: s.InvoicePatchSchema,
+    session: AsyncSession = Depends(db.get_dbsession),
+    current_user: user_model.User = Depends(get_current_user),
+):
+    invoice = await crud.patch_invoice_status(session, invoice_id, data.status, current_user.user_id)
+    if not invoice:
+        raise HTTPException(status_code=404, detail="請求書が見つかりません")
+    invoice = await crud.get_invoice(session, invoice_id, current_user.user_id)
+    return to_invoice_schema(invoice)
+
+
+@router.delete("/{invoice_id}", status_code=204)
+async def delete_invoice(
+    invoice_id: int,
+    session: AsyncSession = Depends(db.get_dbsession),
+    current_user: user_model.User = Depends(get_current_user),
+):
+    result = await crud.delete_invoice(session, invoice_id, current_user.user_id)
+    if not result:
+        raise HTTPException(status_code=404, detail="請求書が見つかりません")
+
+
+# ===== プロフィール =====
+
+@router.get("/profile/me", response_model=s.ProfileSchema | None)
+async def get_profile(
+    session: AsyncSession = Depends(db.get_dbsession),
+    current_user: user_model.User = Depends(get_current_user),
+):
+    return await crud.get_profile(session, current_user.user_id)
+
+
+@router.put("/profile/me", response_model=s.ProfileSchema)
+async def upsert_profile(
+    data: s.ProfileCreateSchema,
+    session: AsyncSession = Depends(db.get_dbsession),
+    current_user: user_model.User = Depends(get_current_user),
+):
+    return await crud.upsert_profile(session, data, current_user.user_id)

--- a/schemas/invoice.py
+++ b/schemas/invoice.py
@@ -1,0 +1,124 @@
+from pydantic import BaseModel, Field
+from datetime import datetime
+from decimal import Decimal
+from typing import Literal
+
+
+# ===== Client =====
+
+class ClientCreateSchema(BaseModel):
+    name: str = Field(..., min_length=1, max_length=100)
+    contact_name: str | None = None
+    address: str | None = None
+    email: str | None = None
+
+
+class ClientSchema(ClientCreateSchema):
+    client_id: int
+    created_at: datetime
+
+    class Config:
+        from_attributes = True
+
+
+# ===== InvoiceItemTemplate =====
+
+class ItemTemplateCreateSchema(BaseModel):
+    name: str = Field(..., min_length=1, max_length=100)
+    unit_price: Decimal = Field(..., ge=0)
+    tax_rate: Decimal = Field(Decimal("0.10"), ge=0, le=1)
+
+
+class ItemTemplateSchema(ItemTemplateCreateSchema):
+    template_id: int
+
+    class Config:
+        from_attributes = True
+
+
+# ===== InvoiceItem =====
+
+class InvoiceItemCreateSchema(BaseModel):
+    name: str = Field(..., min_length=1, max_length=100)
+    quantity: int = Field(..., ge=1)
+    unit_price: Decimal = Field(..., ge=0)
+    tax_rate: Decimal = Field(Decimal("0.10"), ge=0, le=1)
+
+
+class InvoiceItemSchema(InvoiceItemCreateSchema):
+    item_id: int
+    subtotal: Decimal
+    tax_amount: Decimal
+    total: Decimal
+
+    class Config:
+        from_attributes = True
+
+
+# ===== Invoice =====
+
+class InvoiceCreateSchema(BaseModel):
+    client_id: int
+    issued_at: datetime
+    due_at: datetime
+    notes: str | None = None
+    items: list[InvoiceItemCreateSchema] = Field(..., min_length=1)
+
+
+class InvoiceUpdateSchema(BaseModel):
+    client_id: int
+    issued_at: datetime
+    due_at: datetime
+    notes: str | None = None
+    items: list[InvoiceItemCreateSchema] = Field(..., min_length=1)
+
+
+class InvoicePatchSchema(BaseModel):
+    status: Literal["unpaid", "paid"]
+
+
+class InvoiceSchema(BaseModel):
+    invoice_id: int
+    invoice_number: str
+    client_id: int
+    client_name: str
+    issued_at: datetime
+    due_at: datetime
+    status: str
+    notes: str | None
+    items: list[InvoiceItemSchema]
+    subtotal: Decimal
+    tax_amount: Decimal
+    total: Decimal
+    created_at: datetime
+
+    class Config:
+        from_attributes = True
+
+
+class InvoiceListSchema(BaseModel):
+    invoice_id: int
+    invoice_number: str
+    client_name: str
+    issued_at: datetime
+    due_at: datetime
+    status: str
+    total: Decimal
+    created_at: datetime
+
+
+# ===== Profile =====
+
+class ProfileCreateSchema(BaseModel):
+    display_name: str = Field(..., min_length=1, max_length=100)
+    company_name: str | None = None
+    address: str | None = None
+    phone: str | None = None
+    bank_info: str | None = None
+
+
+class ProfileSchema(ProfileCreateSchema):
+    profile_id: int
+
+    class Config:
+        from_attributes = True


### PR DESCRIPTION
## Summary

フリーランス向け請求書管理機能のバックエンドを実装。

- **取引先管理** (`/invoices/clients`) — CRUD
- **品目テンプレート** (`/invoices/templates`) — よく使う品目を登録・再利用
- **請求書** (`/invoices/`) — CRUD + 入金ステータス切り替え
- **プロフィール** (`/invoices/profile/me`) — 自分の氏名・口座情報を登録（upsert）

## 主な仕様

| 項目 | 内容 |
|------|------|
| 請求書番号 | `INV-YYYYMM-NNNN` 形式で自動採番 |
| 消費税 | 明細行ごとに税率を設定（デフォルト 10%）|
| 入金ステータス | `unpaid` / `paid` |
| データ分離 | 全リソースを `user_id` でフィルタリング |

## 動作確認済み

- 取引先作成 → 請求書作成（税込計算）→ 一覧取得

## Test plan

- [ ] 取引先を作成・編集・削除できること
- [ ] 請求書を作成すると番号が自動採番されること（INV-202605-0001）
- [ ] 消費税が明細ごとに正しく計算されること
- [ ] 入金ステータスを unpaid → paid に切り替えられること
- [ ] 他ユーザーの請求書にアクセスできないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)