### PR TITLE
feat: 請求書管理フロントエンドを追加

### DIFF
--- a/cruds/invoice.py
+++ b/cruds/invoice.py
@@ -1,0 +1,220 @@
+from decimal import Decimal
+from sqlalchemy import select, func
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+import models.invoice as m
+import schemas.invoice as s
+
+
+# ===== 請求書番号の自動採番 =====
+
+async def generate_invoice_number(session: AsyncSession, user_id: int) -> str:
+    result = await session.execute(
+        select(func.count()).where(m.Invoice.user_id == user_id)
+    )
+    count = result.scalar() + 1
+    from datetime import datetime
+    ym = datetime.now().strftime("%Y%m")
+    return f"INV-{ym}-{count:04d}"
+
+
+# ===== 金額計算ヘルパー =====
+
+def calc_item(item: m.InvoiceItem) -> dict:
+    subtotal = Decimal(str(item.unit_price)) * item.quantity
+    tax_amount = (subtotal * Decimal(str(item.tax_rate))).quantize(Decimal("1"))
+    return {
+        "subtotal": subtotal,
+        "tax_amount": tax_amount,
+        "total": subtotal + tax_amount,
+    }
+
+
+# ===== Client =====
+
+async def create_client(session: AsyncSession, data: s.ClientCreateSchema, user_id: int) -> m.Client:
+    client = m.Client(user_id=user_id, **data.model_dump())
+    session.add(client)
+    await session.commit()
+    await session.refresh(client)
+    return client
+
+
+async def get_clients(session: AsyncSession, user_id: int) -> list[m.Client]:
+    result = await session.execute(
+        select(m.Client).where(m.Client.user_id == user_id).order_by(m.Client.name)
+    )
+    return result.scalars().all()
+
+
+async def get_client(session: AsyncSession, client_id: int, user_id: int) -> m.Client | None:
+    result = await session.execute(
+        select(m.Client).where(m.Client.client_id == client_id, m.Client.user_id == user_id)
+    )
+    return result.scalars().first()
+
+
+async def update_client(session: AsyncSession, client_id: int, data: s.ClientCreateSchema, user_id: int) -> m.Client | None:
+    client = await get_client(session, client_id, user_id)
+    if not client:
+        return None
+    for k, v in data.model_dump().items():
+        setattr(client, k, v)
+    await session.commit()
+    await session.refresh(client)
+    return client
+
+
+async def delete_client(session: AsyncSession, client_id: int, user_id: int) -> m.Client | None:
+    client = await get_client(session, client_id, user_id)
+    if client:
+        await session.delete(client)
+        await session.commit()
+    return client
+
+
+# ===== InvoiceItemTemplate =====
+
+async def create_template(session: AsyncSession, data: s.ItemTemplateCreateSchema, user_id: int) -> m.InvoiceItemTemplate:
+    tmpl = m.InvoiceItemTemplate(user_id=user_id, **data.model_dump())
+    session.add(tmpl)
+    await session.commit()
+    await session.refresh(tmpl)
+    return tmpl
+
+
+async def get_templates(session: AsyncSession, user_id: int) -> list[m.InvoiceItemTemplate]:
+    result = await session.execute(
+        select(m.InvoiceItemTemplate).where(m.InvoiceItemTemplate.user_id == user_id)
+    )
+    return result.scalars().all()
+
+
+async def delete_template(session: AsyncSession, template_id: int, user_id: int) -> m.InvoiceItemTemplate | None:
+    result = await session.execute(
+        select(m.InvoiceItemTemplate).where(
+            m.InvoiceItemTemplate.template_id == template_id,
+            m.InvoiceItemTemplate.user_id == user_id,
+        )
+    )
+    tmpl = result.scalars().first()
+    if tmpl:
+        await session.delete(tmpl)
+        await session.commit()
+    return tmpl
+
+
+# ===== Invoice =====
+
+async def create_invoice(session: AsyncSession, data: s.InvoiceCreateSchema, user_id: int) -> m.Invoice:
+    invoice_number = await generate_invoice_number(session, user_id)
+    invoice = m.Invoice(
+        user_id=user_id,
+        client_id=data.client_id,
+        invoice_number=invoice_number,
+        issued_at=data.issued_at,
+        due_at=data.due_at,
+        notes=data.notes,
+        status="unpaid",
+    )
+    session.add(invoice)
+    await session.flush()
+
+    for item_data in data.items:
+        item = m.InvoiceItem(invoice_id=invoice.invoice_id, **item_data.model_dump())
+        session.add(item)
+
+    await session.commit()
+    await session.refresh(invoice)
+    return invoice
+
+
+async def get_invoices(
+    session: AsyncSession,
+    user_id: int,
+    status: str | None = None,
+    client_id: int | None = None,
+) -> list[m.Invoice]:
+    query = (
+        select(m.Invoice)
+        .options(selectinload(m.Invoice.client), selectinload(m.Invoice.items))
+        .where(m.Invoice.user_id == user_id)
+    )
+    if status:
+        query = query.where(m.Invoice.status == status)
+    if client_id:
+        query = query.where(m.Invoice.client_id == client_id)
+    query = query.order_by(m.Invoice.issued_at.desc())
+    result = await session.execute(query)
+    return result.scalars().all()
+
+
+async def get_invoice(session: AsyncSession, invoice_id: int, user_id: int) -> m.Invoice | None:
+    result = await session.execute(
+        select(m.Invoice)
+        .options(selectinload(m.Invoice.client), selectinload(m.Invoice.items))
+        .where(m.Invoice.invoice_id == invoice_id, m.Invoice.user_id == user_id)
+    )
+    return result.scalars().first()
+
+
+async def update_invoice(session: AsyncSession, invoice_id: int, data: s.InvoiceUpdateSchema, user_id: int) -> m.Invoice | None:
+    invoice = await get_invoice(session, invoice_id, user_id)
+    if not invoice:
+        return None
+    invoice.client_id = data.client_id
+    invoice.issued_at = data.issued_at
+    invoice.due_at = data.due_at
+    invoice.notes = data.notes
+
+    for item in invoice.items:
+        await session.delete(item)
+    await session.flush()
+
+    for item_data in data.items:
+        item = m.InvoiceItem(invoice_id=invoice.invoice_id, **item_data.model_dump())
+        session.add(item)
+
+    await session.commit()
+    await session.refresh(invoice)
+    return invoice
+
+
+async def patch_invoice_status(session: AsyncSession, invoice_id: int, status: str, user_id: int) -> m.Invoice | None:
+    invoice = await get_invoice(session, invoice_id, user_id)
+    if not invoice:
+        return None
+    invoice.status = status
+    await session.commit()
+    await session.refresh(invoice)
+    return invoice
+
+
+async def delete_invoice(session: AsyncSession, invoice_id: int, user_id: int) -> m.Invoice | None:
+    invoice = await get_invoice(session, invoice_id, user_id)
+    if invoice:
+        await session.delete(invoice)
+        await session.commit()
+    return invoice
+
+
+# ===== Profile =====
+
+async def get_profile(session: AsyncSession, user_id: int) -> m.Profile | None:
+    result = await session.execute(
+        select(m.Profile).where(m.Profile.user_id == user_id)
+    )
+    return result.scalars().first()
+
+
+async def upsert_profile(session: AsyncSession, data: s.ProfileCreateSchema, user_id: int) -> m.Profile:
+    profile = await get_profile(session, user_id)
+    if profile:
+        for k, v in data.model_dump().items():
+            setattr(profile, k, v)
+    else:
+        profile = m.Profile(user_id=user_id, **data.model_dump())
+        session.add(profile)
+    await session.commit()
+    await session.refresh(profile)
+    return profile

--- a/frontapp-react/src/App.jsx
+++ b/frontapp-react/src/App.jsx
@@ -5,6 +5,11 @@ import ListMemos from "./ListMemos";
 import EditMemo from "./EditMemo";
 import Login from "./Login";
 import Register from "./Register";
+import InvoiceList from "./invoices/InvoiceList";
+import InvoiceCreate from "./invoices/InvoiceCreate";
+import InvoiceDetail from "./invoices/InvoiceDetail";
+import ClientList from "./clients/ClientList";
+import Profile from "./Profile";
 
 function PrivateRoute({ children }) {
   return isLoggedIn() ? children : <Navigate to="/login" replace />;
@@ -24,6 +29,11 @@ function App() {
         <Route path="/list" element={<PrivateRoute><ListMemos /></PrivateRoute>} />
         <Route path="/create" element={<PrivateRoute><CreateMemo /></PrivateRoute>} />
         <Route path="/memos/:id/edit" element={<PrivateRoute><EditMemo /></PrivateRoute>} />
+        <Route path="/invoices" element={<PrivateRoute><InvoiceList /></PrivateRoute>} />
+        <Route path="/invoices/create" element={<PrivateRoute><InvoiceCreate /></PrivateRoute>} />
+        <Route path="/invoices/:id" element={<PrivateRoute><InvoiceDetail /></PrivateRoute>} />
+        <Route path="/clients" element={<PrivateRoute><ClientList /></PrivateRoute>} />
+        <Route path="/profile" element={<PrivateRoute><Profile /></PrivateRoute>} />
         <Route path="*" element={<Navigate to="/list" replace />} />
       </Routes>
     </BrowserRouter>

--- a/frontapp-react/src/Profile.jsx
+++ b/frontapp-react/src/Profile.jsx
@@ -1,0 +1,98 @@
+import { useEffect, useState } from "react";
+import Header from "./components/Header";
+import { BASE_URL, authFetch } from "./utils/api";
+
+const EMPTY = { display_name: "", company_name: "", address: "", phone: "", bank_info: "" };
+
+function Profile() {
+  const [form, setForm] = useState(EMPTY);
+  const [loading, setLoading] = useState(true);
+  const [submitting, setSubmitting] = useState(false);
+  const [success, setSuccess] = useState("");
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    authFetch(`${BASE_URL}/invoices/profile/me`)
+      .then((r) => r.json())
+      .then((data) => { if (data) setForm(data); })
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  }, []);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError(""); setSuccess("");
+    setSubmitting(true);
+    try {
+      const res = await authFetch(`${BASE_URL}/invoices/profile/me`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(form),
+      });
+      if (!res.ok) throw new Error("保存に失敗しました");
+      setSuccess("保存しました");
+      setTimeout(() => setSuccess(""), 3000);
+    } catch (e) {
+      setError(e.message);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (loading) return <><Header /><div className="page"><p>読み込み中...</p></div></>;
+
+  return (
+    <>
+      <Header />
+      <main className="page">
+        <div className="page-header">
+          <h2 className="page-title">プロフィール設定</h2>
+        </div>
+
+        {error && <div className="alert-error">{error}</div>}
+        {success && <div className="alert-success">{success}</div>}
+
+        <div className="form-card">
+          <h3 className="section-title">請求書に表示される情報</h3>
+          <form onSubmit={handleSubmit}>
+            <div className="form-row two-col">
+              <div className="form-group">
+                <label className="form-label">氏名 <span className="required">*</span></label>
+                <input className="form-input" value={form.display_name} onChange={(e) => setForm({ ...form, display_name: e.target.value })} required />
+              </div>
+              <div className="form-group">
+                <label className="form-label">屋号・会社名</label>
+                <input className="form-input" value={form.company_name || ""} onChange={(e) => setForm({ ...form, company_name: e.target.value })} />
+              </div>
+            </div>
+            <div className="form-row two-col">
+              <div className="form-group">
+                <label className="form-label">住所</label>
+                <input className="form-input" value={form.address || ""} onChange={(e) => setForm({ ...form, address: e.target.value })} />
+              </div>
+              <div className="form-group">
+                <label className="form-label">電話番号</label>
+                <input className="form-input" value={form.phone || ""} onChange={(e) => setForm({ ...form, phone: e.target.value })} />
+              </div>
+            </div>
+            <div className="form-group">
+              <label className="form-label">振込先口座情報</label>
+              <textarea
+                className="form-textarea"
+                rows={3}
+                placeholder={"例:\n〇〇銀行 △△支店 普通 1234567\n口座名義: 山田 太郎"}
+                value={form.bank_info || ""}
+                onChange={(e) => setForm({ ...form, bank_info: e.target.value })}
+              />
+            </div>
+            <button type="submit" className="btn btn-primary" disabled={submitting}>
+              {submitting ? "保存中..." : "保存する"}
+            </button>
+          </form>
+        </div>
+      </main>
+    </>
+  );
+}
+
+export default Profile;

--- a/frontapp-react/src/clients/ClientList.jsx
+++ b/frontapp-react/src/clients/ClientList.jsx
@@ -1,0 +1,148 @@
+import { useEffect, useState } from "react";
+import Header from "../components/Header";
+import { BASE_URL, authFetch } from "../utils/api";
+
+const EMPTY_FORM = { name: "", contact_name: "", address: "", email: "" };
+
+function ClientList() {
+  const [clients, setClients] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [showForm, setShowForm] = useState(false);
+  const [editTarget, setEditTarget] = useState(null);
+  const [form, setForm] = useState(EMPTY_FORM);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState("");
+
+  const fetchClients = async () => {
+    try {
+      const res = await authFetch(`${BASE_URL}/invoices/clients`);
+      setClients(await res.json());
+    } catch (e) {
+      setError(e.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => { fetchClients(); }, []);
+
+  const openCreate = () => { setForm(EMPTY_FORM); setEditTarget(null); setShowForm(true); };
+  const openEdit = (client) => {
+    setForm({ name: client.name, contact_name: client.contact_name || "", address: client.address || "", email: client.email || "" });
+    setEditTarget(client);
+    setShowForm(true);
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setSubmitting(true);
+    try {
+      const url = editTarget
+        ? `${BASE_URL}/invoices/clients/${editTarget.client_id}`
+        : `${BASE_URL}/invoices/clients`;
+      const method = editTarget ? "PUT" : "POST";
+      const res = await authFetch(url, {
+        method,
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(form),
+      });
+      if (!res.ok) throw new Error("保存失敗");
+      setShowForm(false);
+      fetchClients();
+    } catch (e) {
+      setError(e.message);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleDelete = async (id) => {
+    if (!window.confirm("削除しますか？")) return;
+    await authFetch(`${BASE_URL}/invoices/clients/${id}`, { method: "DELETE" });
+    setClients((prev) => prev.filter((c) => c.client_id !== id));
+  };
+
+  return (
+    <>
+      <Header />
+      <main className="page">
+        <div className="page-header">
+          <h2 className="page-title">取引先管理</h2>
+          <button className="btn btn-primary" onClick={openCreate}>+ 追加</button>
+        </div>
+
+        {error && <div className="alert-error">{error}</div>}
+
+        {showForm && (
+          <div className="form-card" style={{ marginBottom: 20 }}>
+            <h3 className="section-title">{editTarget ? "取引先を編集" : "取引先を追加"}</h3>
+            <form onSubmit={handleSubmit}>
+              <div className="form-row two-col">
+                <div className="form-group">
+                  <label className="form-label">会社名 <span className="required">*</span></label>
+                  <input className="form-input" value={form.name} onChange={(e) => setForm({ ...form, name: e.target.value })} required />
+                </div>
+                <div className="form-group">
+                  <label className="form-label">担当者名</label>
+                  <input className="form-input" value={form.contact_name} onChange={(e) => setForm({ ...form, contact_name: e.target.value })} />
+                </div>
+              </div>
+              <div className="form-row two-col">
+                <div className="form-group">
+                  <label className="form-label">メールアドレス</label>
+                  <input className="form-input" type="email" value={form.email} onChange={(e) => setForm({ ...form, email: e.target.value })} />
+                </div>
+                <div className="form-group">
+                  <label className="form-label">住所</label>
+                  <input className="form-input" value={form.address} onChange={(e) => setForm({ ...form, address: e.target.value })} />
+                </div>
+              </div>
+              <div style={{ display: "flex", gap: 8 }}>
+                <button type="submit" className="btn btn-primary" disabled={submitting}>{submitting ? "保存中..." : "保存"}</button>
+                <button type="button" className="btn btn-ghost" onClick={() => setShowForm(false)}>キャンセル</button>
+              </div>
+            </form>
+          </div>
+        )}
+
+        {loading ? (
+          <p style={{ color: "#9ca3af" }}>読み込み中...</p>
+        ) : clients.length === 0 ? (
+          <div className="empty-state"><p>取引先がまだありません</p></div>
+        ) : (
+          <div className="invoice-table-wrap">
+            <table className="invoice-table">
+              <thead>
+                <tr>
+                  <th>会社名</th>
+                  <th>担当者</th>
+                  <th>メール</th>
+                  <th>住所</th>
+                  <th></th>
+                </tr>
+              </thead>
+              <tbody>
+                {clients.map((c) => (
+                  <tr key={c.client_id}>
+                    <td style={{ fontWeight: 600 }}>{c.name}</td>
+                    <td>{c.contact_name || "-"}</td>
+                    <td>{c.email || "-"}</td>
+                    <td>{c.address || "-"}</td>
+                    <td>
+                      <div style={{ display: "flex", gap: 4 }}>
+                        <button className="btn btn-sm btn-outline-primary" onClick={() => openEdit(c)}>編集</button>
+                        <button className="btn btn-sm btn-danger" onClick={() => handleDelete(c.client_id)}>削除</button>
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </main>
+    </>
+  );
+}
+
+export default ClientList;

--- a/frontapp-react/src/components/Header.jsx
+++ b/frontapp-react/src/components/Header.jsx
@@ -1,4 +1,4 @@
-import { useNavigate } from "react-router-dom";
+import { useNavigate, NavLink } from "react-router-dom";
 import { removeToken } from "../utils/auth";
 
 function Header() {
@@ -11,7 +11,23 @@ function Header() {
 
   return (
     <header className="app-header">
-      <h1>メモアプリ</h1>
+      <div className="header-left">
+        <span className="app-logo">MyApp</span>
+        <nav className="header-nav">
+          <NavLink to="/list" className={({ isActive }) => "nav-link" + (isActive ? " active" : "")}>
+            メモ
+          </NavLink>
+          <NavLink to="/invoices" className={({ isActive }) => "nav-link" + (isActive ? " active" : "")}>
+            請求書
+          </NavLink>
+          <NavLink to="/clients" className={({ isActive }) => "nav-link" + (isActive ? " active" : "")}>
+            取引先
+          </NavLink>
+          <NavLink to="/profile" className={({ isActive }) => "nav-link" + (isActive ? " active" : "")}>
+            設定
+          </NavLink>
+        </nav>
+      </div>
       <button className="btn btn-ghost btn-sm" onClick={handleLogout}>
         ログアウト
       </button>

--- a/frontapp-react/src/invoices/InvoiceCreate.jsx
+++ b/frontapp-react/src/invoices/InvoiceCreate.jsx
@@ -1,0 +1,235 @@
+import { useEffect, useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import Header from "../components/Header";
+import { BASE_URL, authFetch } from "../utils/api";
+
+const DEFAULT_ITEM = { name: "", quantity: 1, unit_price: "", tax_rate: "0.10" };
+
+function calcItem(item) {
+  const subtotal = Number(item.unit_price) * Number(item.quantity);
+  const tax = Math.floor(subtotal * Number(item.tax_rate));
+  return { subtotal, tax, total: subtotal + tax };
+}
+
+function formatAmount(n) {
+  return Number(n).toLocaleString("ja-JP");
+}
+
+function today() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function nextMonth() {
+  const d = new Date();
+  d.setMonth(d.getMonth() + 1);
+  return d.toISOString().slice(0, 10);
+}
+
+function InvoiceCreate() {
+  const navigate = useNavigate();
+  const [clients, setClients] = useState([]);
+  const [clientId, setClientId] = useState("");
+  const [issuedAt, setIssuedAt] = useState(today());
+  const [dueAt, setDueAt] = useState(nextMonth());
+  const [notes, setNotes] = useState("");
+  const [items, setItems] = useState([{ ...DEFAULT_ITEM }]);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    authFetch(`${BASE_URL}/invoices/clients`)
+      .then((r) => r.json())
+      .then(setClients)
+      .catch(() => {});
+  }, []);
+
+  const updateItem = (i, field, value) => {
+    setItems((prev) => prev.map((item, idx) => idx === i ? { ...item, [field]: value } : item));
+  };
+
+  const addItem = () => setItems((prev) => [...prev, { ...DEFAULT_ITEM }]);
+  const removeItem = (i) => setItems((prev) => prev.filter((_, idx) => idx !== i));
+
+  const totals = items.reduce(
+    (acc, item) => {
+      const { subtotal, tax, total } = calcItem(item);
+      return { subtotal: acc.subtotal + subtotal, tax: acc.tax + tax, total: acc.total + total };
+    },
+    { subtotal: 0, tax: 0, total: 0 }
+  );
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError("");
+    if (!clientId) { setError("取引先を選択してください"); return; }
+    if (items.some((item) => !item.name || !item.unit_price)) {
+      setError("品目名と単価を入力してください");
+      return;
+    }
+    try {
+      setSubmitting(true);
+      const payload = {
+        client_id: Number(clientId),
+        issued_at: `${issuedAt}T00:00:00`,
+        due_at: `${dueAt}T00:00:00`,
+        notes: notes || null,
+        items: items.map((item) => ({
+          name: item.name,
+          quantity: Number(item.quantity),
+          unit_price: Number(item.unit_price),
+          tax_rate: Number(item.tax_rate),
+        })),
+      };
+      const res = await authFetch(`${BASE_URL}/invoices/`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      if (!res.ok) throw new Error("作成に失敗しました");
+      const data = await res.json();
+      navigate(`/invoices/${data.invoice_id}`);
+    } catch (e) {
+      setError(e.message);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <>
+      <Header />
+      <main className="page">
+        <div className="page-header">
+          <h2 className="page-title">請求書作成</h2>
+          <Link to="/invoices" className="btn btn-ghost">← 一覧へ</Link>
+        </div>
+
+        {error && <div className="alert-error">{error}</div>}
+
+        <form onSubmit={handleSubmit}>
+          <div className="form-card" style={{ marginBottom: 16 }}>
+            <h3 className="section-title">基本情報</h3>
+            <div className="form-row">
+              <div className="form-group">
+                <label className="form-label">取引先 <span className="required">*</span></label>
+                <select className="form-select" value={clientId} onChange={(e) => setClientId(e.target.value)} required>
+                  <option value="">選択してください</option>
+                  {clients.map((c) => (
+                    <option key={c.client_id} value={c.client_id}>{c.name}</option>
+                  ))}
+                </select>
+                {clients.length === 0 && (
+                  <p style={{ fontSize: 12, color: "#9ca3af", marginTop: 4 }}>
+                    <Link to="/clients">取引先を先に登録してください</Link>
+                  </p>
+                )}
+              </div>
+            </div>
+            <div className="form-row two-col">
+              <div className="form-group">
+                <label className="form-label">請求日 <span className="required">*</span></label>
+                <input className="form-input" type="date" value={issuedAt} onChange={(e) => setIssuedAt(e.target.value)} required />
+              </div>
+              <div className="form-group">
+                <label className="form-label">支払期限 <span className="required">*</span></label>
+                <input className="form-input" type="date" value={dueAt} onChange={(e) => setDueAt(e.target.value)} required />
+              </div>
+            </div>
+            <div className="form-group">
+              <label className="form-label">備考</label>
+              <textarea className="form-textarea" value={notes} onChange={(e) => setNotes(e.target.value)} rows={2} />
+            </div>
+          </div>
+
+          <div className="form-card" style={{ marginBottom: 16 }}>
+            <h3 className="section-title">明細</h3>
+            <table className="items-edit-table">
+              <thead>
+                <tr>
+                  <th>品目名</th>
+                  <th style={{ width: 80 }}>数量</th>
+                  <th style={{ width: 130 }}>単価（円）</th>
+                  <th style={{ width: 100 }}>税率</th>
+                  <th style={{ width: 120, textAlign: "right" }}>小計（税込）</th>
+                  <th style={{ width: 40 }}></th>
+                </tr>
+              </thead>
+              <tbody>
+                {items.map((item, i) => {
+                  const { total } = calcItem(item);
+                  return (
+                    <tr key={i}>
+                      <td>
+                        <input
+                          className="form-input"
+                          type="text"
+                          placeholder="例: Webサイト制作"
+                          value={item.name}
+                          onChange={(e) => updateItem(i, "name", e.target.value)}
+                          required
+                        />
+                      </td>
+                      <td>
+                        <input
+                          className="form-input"
+                          type="number"
+                          min={1}
+                          value={item.quantity}
+                          onChange={(e) => updateItem(i, "quantity", e.target.value)}
+                        />
+                      </td>
+                      <td>
+                        <input
+                          className="form-input"
+                          type="number"
+                          min={0}
+                          placeholder="300000"
+                          value={item.unit_price}
+                          onChange={(e) => updateItem(i, "unit_price", e.target.value)}
+                          required
+                        />
+                      </td>
+                      <td>
+                        <select className="form-select" value={item.tax_rate} onChange={(e) => updateItem(i, "tax_rate", e.target.value)}>
+                          <option value="0.10">10%</option>
+                          <option value="0.08">8%</option>
+                          <option value="0.00">非課税</option>
+                        </select>
+                      </td>
+                      <td style={{ textAlign: "right", fontWeight: 600 }}>
+                        {item.unit_price ? formatAmount(total) + " 円" : "-"}
+                      </td>
+                      <td>
+                        {items.length > 1 && (
+                          <button type="button" className="btn btn-sm btn-danger" onClick={() => removeItem(i)}>×</button>
+                        )}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+            <button type="button" className="btn btn-ghost btn-sm" style={{ marginTop: 8 }} onClick={addItem}>
+              + 行を追加
+            </button>
+
+            <div className="invoice-totals">
+              <div className="total-row"><span>小計</span><span>{formatAmount(totals.subtotal)} 円</span></div>
+              <div className="total-row"><span>消費税</span><span>{formatAmount(totals.tax)} 円</span></div>
+              <div className="total-row total-final"><span>合計（税込）</span><span>{formatAmount(totals.total)} 円</span></div>
+            </div>
+          </div>
+
+          <div style={{ display: "flex", gap: 12 }}>
+            <button type="submit" className="btn btn-primary" disabled={submitting}>
+              {submitting ? "作成中..." : "請求書を作成する"}
+            </button>
+            <Link to="/invoices" className="btn btn-ghost">キャンセル</Link>
+          </div>
+        </form>
+      </main>
+    </>
+  );
+}
+
+export default InvoiceCreate;

--- a/frontapp-react/src/invoices/InvoiceDetail.jsx
+++ b/frontapp-react/src/invoices/InvoiceDetail.jsx
@@ -1,0 +1,111 @@
+import { useEffect, useState } from "react";
+import { Link, useParams, useNavigate } from "react-router-dom";
+import Header from "../components/Header";
+import { BASE_URL, authFetch } from "../utils/api";
+
+function formatDate(value) {
+  if (!value) return "-";
+  return new Date(value).toLocaleDateString("ja-JP", { year: "numeric", month: "2-digit", day: "2-digit" });
+}
+
+function formatAmount(value) {
+  return Number(value).toLocaleString("ja-JP") + " 円";
+}
+
+function InvoiceDetail() {
+  const { id } = useParams();
+  const navigate = useNavigate();
+  const [invoice, setInvoice] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    authFetch(`${BASE_URL}/invoices/${id}`)
+      .then((r) => { if (!r.ok) throw new Error("取得失敗"); return r.json(); })
+      .then(setInvoice)
+      .catch((e) => setError(e.message))
+      .finally(() => setLoading(false));
+  }, [id]);
+
+  const toggleStatus = async () => {
+    const next = invoice.status === "unpaid" ? "paid" : "unpaid";
+    const res = await authFetch(`${BASE_URL}/invoices/${id}/status`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ status: next }),
+    });
+    if (res.ok) setInvoice((prev) => ({ ...prev, status: next }));
+  };
+
+  const handleDelete = async () => {
+    if (!window.confirm("削除しますか？")) return;
+    const res = await authFetch(`${BASE_URL}/invoices/${id}`, { method: "DELETE" });
+    if (res.ok) navigate("/invoices");
+  };
+
+  if (loading) return <><Header /><div className="page"><p>読み込み中...</p></div></>;
+  if (error || !invoice) return <><Header /><div className="page"><div className="alert-error">{error}</div></div></>;
+
+  return (
+    <>
+      <Header />
+      <main className="page">
+        <div className="page-header">
+          <h2 className="page-title">{invoice.invoice_number}</h2>
+          <div style={{ display: "flex", gap: 8 }}>
+            <button
+              className={`status-badge ${invoice.status === "paid" ? "status-paid" : "status-unpaid"}`}
+              onClick={toggleStatus}
+            >
+              {invoice.status === "paid" ? "入金済み" : "未入金"}
+            </button>
+            <button className="btn btn-sm btn-danger" onClick={handleDelete}>削除</button>
+            <Link to="/invoices" className="btn btn-ghost btn-sm">← 一覧へ</Link>
+          </div>
+        </div>
+
+        <div className="form-card" style={{ marginBottom: 16 }}>
+          <div className="detail-grid">
+            <div><span className="detail-label">取引先</span><span className="detail-value">{invoice.client_name}</span></div>
+            <div><span className="detail-label">請求日</span><span className="detail-value">{formatDate(invoice.issued_at)}</span></div>
+            <div><span className="detail-label">支払期限</span><span className="detail-value">{formatDate(invoice.due_at)}</span></div>
+            {invoice.notes && <div style={{ gridColumn: "1 / -1" }}><span className="detail-label">備考</span><span className="detail-value">{invoice.notes}</span></div>}
+          </div>
+        </div>
+
+        <div className="form-card" style={{ marginBottom: 16 }}>
+          <h3 className="section-title">明細</h3>
+          <table className="invoice-table">
+            <thead>
+              <tr>
+                <th>品目</th>
+                <th style={{ textAlign: "right" }}>数量</th>
+                <th style={{ textAlign: "right" }}>単価</th>
+                <th style={{ textAlign: "right" }}>税率</th>
+                <th style={{ textAlign: "right" }}>小計（税込）</th>
+              </tr>
+            </thead>
+            <tbody>
+              {invoice.items.map((item) => (
+                <tr key={item.item_id}>
+                  <td>{item.name}</td>
+                  <td style={{ textAlign: "right" }}>{item.quantity}</td>
+                  <td style={{ textAlign: "right" }}>{formatAmount(item.unit_price)}</td>
+                  <td style={{ textAlign: "right" }}>{(Number(item.tax_rate) * 100).toFixed(0)}%</td>
+                  <td style={{ textAlign: "right", fontWeight: 600 }}>{formatAmount(item.total)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          <div className="invoice-totals">
+            <div className="total-row"><span>小計</span><span>{formatAmount(invoice.subtotal)}</span></div>
+            <div className="total-row"><span>消費税</span><span>{formatAmount(invoice.tax_amount)}</span></div>
+            <div className="total-row total-final"><span>合計（税込）</span><span>{formatAmount(invoice.total)}</span></div>
+          </div>
+        </div>
+      </main>
+    </>
+  );
+}
+
+export default InvoiceDetail;

--- a/frontapp-react/src/invoices/InvoiceList.jsx
+++ b/frontapp-react/src/invoices/InvoiceList.jsx
@@ -1,0 +1,161 @@
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import Header from "../components/Header";
+import { BASE_URL, authFetch } from "../utils/api";
+
+function formatDate(value) {
+  if (!value) return "-";
+  return new Date(value).toLocaleDateString("ja-JP", { year: "numeric", month: "2-digit", day: "2-digit" });
+}
+
+function formatAmount(value) {
+  return Number(value).toLocaleString("ja-JP") + " 円";
+}
+
+function InvoiceList() {
+  const [invoices, setInvoices] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [statusFilter, setStatusFilter] = useState("");
+  const [error, setError] = useState("");
+
+  const fetchInvoices = async (status) => {
+    try {
+      setLoading(true);
+      setError("");
+      const qs = status ? `?status=${status}` : "";
+      const res = await authFetch(`${BASE_URL}/invoices/${qs}`);
+      if (!res.ok) throw new Error("取得失敗");
+      setInvoices(await res.json());
+    } catch (e) {
+      setError(e.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => { fetchInvoices(statusFilter); }, [statusFilter]);
+
+  const toggleStatus = async (invoice) => {
+    const next = invoice.status === "unpaid" ? "paid" : "unpaid";
+    try {
+      const res = await authFetch(`${BASE_URL}/invoices/${invoice.invoice_id}/status`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ status: next }),
+      });
+      if (!res.ok) throw new Error("更新失敗");
+      setInvoices((prev) =>
+        prev.map((inv) => inv.invoice_id === invoice.invoice_id ? { ...inv, status: next } : inv)
+      );
+    } catch (e) {
+      alert(e.message);
+    }
+  };
+
+  const handleDelete = async (id) => {
+    if (!window.confirm("削除しますか？")) return;
+    try {
+      const res = await authFetch(`${BASE_URL}/invoices/${id}`, { method: "DELETE" });
+      if (!res.ok) throw new Error("削除失敗");
+      setInvoices((prev) => prev.filter((inv) => inv.invoice_id !== id));
+    } catch (e) {
+      alert(e.message);
+    }
+  };
+
+  const unpaidTotal = invoices
+    .filter((inv) => inv.status === "unpaid")
+    .reduce((sum, inv) => sum + Number(inv.total), 0);
+
+  return (
+    <>
+      <Header />
+      <main className="page">
+        <div className="page-header">
+          <h2 className="page-title">請求書一覧</h2>
+          <Link to="/invoices/create" className="btn btn-primary">+ 新規作成</Link>
+        </div>
+
+        {unpaidTotal > 0 && (
+          <div className="summary-card">
+            <span className="summary-label">未入金合計</span>
+            <span className="summary-amount">{formatAmount(unpaidTotal)}</span>
+          </div>
+        )}
+
+        <div className="filter-bar">
+          <select
+            className="form-select filter-select"
+            value={statusFilter}
+            onChange={(e) => setStatusFilter(e.target.value)}
+          >
+            <option value="">状態: 全て</option>
+            <option value="unpaid">未入金</option>
+            <option value="paid">入金済み</option>
+          </select>
+        </div>
+
+        {error && <div className="alert-error">{error}</div>}
+
+        {loading ? (
+          <p style={{ color: "#9ca3af" }}>読み込み中...</p>
+        ) : invoices.length === 0 ? (
+          <div className="empty-state">
+            <p>請求書がありません</p>
+            <Link to="/invoices/create" className="btn btn-primary">最初の請求書を作成する</Link>
+          </div>
+        ) : (
+          <div className="invoice-table-wrap">
+            <table className="invoice-table">
+              <thead>
+                <tr>
+                  <th>請求書番号</th>
+                  <th>取引先</th>
+                  <th>請求日</th>
+                  <th>支払期限</th>
+                  <th style={{ textAlign: "right" }}>金額（税込）</th>
+                  <th>状態</th>
+                  <th></th>
+                </tr>
+              </thead>
+              <tbody>
+                {invoices.map((inv) => (
+                  <tr key={inv.invoice_id} className={inv.status === "paid" ? "row-paid" : ""}>
+                    <td>
+                      <Link to={`/invoices/${inv.invoice_id}`} className="invoice-number-link">
+                        {inv.invoice_number}
+                      </Link>
+                    </td>
+                    <td>{inv.client_name}</td>
+                    <td>{formatDate(inv.issued_at)}</td>
+                    <td>{formatDate(inv.due_at)}</td>
+                    <td style={{ textAlign: "right", fontWeight: 600 }}>{formatAmount(inv.total)}</td>
+                    <td>
+                      <button
+                        className={`status-badge ${inv.status === "paid" ? "status-paid" : "status-unpaid"}`}
+                        onClick={() => toggleStatus(inv)}
+                        title="クリックで切り替え"
+                      >
+                        {inv.status === "paid" ? "入金済み" : "未入金"}
+                      </button>
+                    </td>
+                    <td>
+                      <button
+                        className="btn btn-sm btn-danger"
+                        onClick={() => handleDelete(inv.invoice_id)}
+                      >
+                        削除
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </main>
+    </>
+  );
+}
+
+export default InvoiceList;

--- a/frontapp-react/src/styles.css
+++ b/frontapp-react/src/styles.css
@@ -369,3 +369,220 @@ body {
   font-size: 14px;
   margin-bottom: 16px;
 }
+
+/* ===== ヘッダーナビゲーション ===== */
+.header-left {
+  display: flex;
+  align-items: center;
+  gap: 24px;
+}
+
+.app-logo {
+  font-size: 18px;
+  font-weight: 700;
+  color: #2563eb;
+}
+
+.header-nav {
+  display: flex;
+  gap: 4px;
+}
+
+.nav-link {
+  padding: 6px 12px;
+  border-radius: 6px;
+  font-size: 14px;
+  font-weight: 500;
+  color: #6b7280;
+  text-decoration: none;
+  transition: background 0.15s, color 0.15s;
+}
+
+.nav-link:hover {
+  background-color: #f3f4f6;
+  color: #1a1a2e;
+}
+
+.nav-link.active {
+  background-color: #eff6ff;
+  color: #2563eb;
+}
+
+/* ===== 請求書テーブル ===== */
+.invoice-table-wrap {
+  overflow-x: auto;
+}
+
+.invoice-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 14px;
+}
+
+.invoice-table th {
+  text-align: left;
+  padding: 10px 12px;
+  border-bottom: 2px solid #e8e8e8;
+  font-weight: 600;
+  color: #6b7280;
+  white-space: nowrap;
+}
+
+.invoice-table td {
+  padding: 12px 12px;
+  border-bottom: 1px solid #f3f4f6;
+  vertical-align: middle;
+}
+
+.invoice-table tr:hover td {
+  background-color: #f9fafb;
+}
+
+.invoice-table tr.row-paid td {
+  opacity: 0.6;
+}
+
+.invoice-number-link {
+  color: #2563eb;
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.invoice-number-link:hover {
+  text-decoration: underline;
+}
+
+/* ===== ステータスバッジ ===== */
+.status-badge {
+  display: inline-block;
+  padding: 4px 10px;
+  border-radius: 99px;
+  font-size: 12px;
+  font-weight: 600;
+  border: none;
+  cursor: pointer;
+}
+
+.status-unpaid {
+  background-color: #fef3c7;
+  color: #d97706;
+}
+
+.status-paid {
+  background-color: #d1fae5;
+  color: #059669;
+}
+
+/* ===== 未入金合計サマリー ===== */
+.summary-card {
+  background: linear-gradient(135deg, #eff6ff, #dbeafe);
+  border: 1px solid #bfdbfe;
+  border-radius: 12px;
+  padding: 16px 24px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 20px;
+}
+
+.summary-label {
+  font-size: 14px;
+  color: #3b82f6;
+  font-weight: 500;
+}
+
+.summary-amount {
+  font-size: 22px;
+  font-weight: 700;
+  color: #1d4ed8;
+}
+
+/* ===== 明細編集テーブル ===== */
+.items-edit-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 14px;
+  margin-bottom: 8px;
+}
+
+.items-edit-table th {
+  text-align: left;
+  padding: 8px 6px;
+  border-bottom: 2px solid #e8e8e8;
+  font-weight: 600;
+  color: #6b7280;
+}
+
+.items-edit-table td {
+  padding: 6px 6px;
+  vertical-align: middle;
+}
+
+/* ===== 請求合計 ===== */
+.invoice-totals {
+  margin-top: 16px;
+  border-top: 1px solid #e8e8e8;
+  padding-top: 12px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 6px;
+}
+
+.total-row {
+  display: flex;
+  gap: 32px;
+  font-size: 14px;
+  color: #6b7280;
+}
+
+.total-final {
+  font-size: 18px;
+  font-weight: 700;
+  color: #1a1a2e;
+  border-top: 2px solid #e8e8e8;
+  padding-top: 8px;
+  margin-top: 4px;
+}
+
+/* ===== フォームレイアウト ===== */
+.form-row {
+  display: flex;
+  gap: 16px;
+}
+
+.form-row.two-col > * {
+  flex: 1;
+}
+
+.section-title {
+  font-size: 15px;
+  font-weight: 600;
+  color: #374151;
+  margin-bottom: 16px;
+}
+
+/* ===== 詳細グリッド ===== */
+.detail-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 16px;
+}
+
+.detail-label {
+  display: block;
+  font-size: 12px;
+  color: #9ca3af;
+  margin-bottom: 4px;
+}
+
+.detail-value {
+  font-size: 15px;
+  font-weight: 500;
+  color: #1a1a2e;
+}
+
+.required {
+  color: #dc2626;
+  margin-left: 2px;
+}

--- a/main.py
+++ b/main.py
@@ -8,8 +8,10 @@ from sqlalchemy import text
 from db import engine, Base
 from routers.memo import router as memo_router
 from routers.auth import router as auth_router
+from routers.invoice import router as invoice_router
 import models.memo  # noqa: F401
 import models.user  # noqa: F401
+import models.invoice  # noqa: F401
 
 
 @asynccontextmanager
@@ -46,6 +48,7 @@ app.add_middleware(
 
 app.include_router(auth_router)
 app.include_router(memo_router)
+app.include_router(invoice_router)
 
 
 @app.exception_handler(ValidationError)

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,4 +1,5 @@
 from .memo import Memo
 from .user import User
+from .invoice import Client, InvoiceItemTemplate, Invoice, InvoiceItem, Profile
 
-__all__ = ["Memo", "User"]
+__all__ = ["Memo", "User", "Client", "InvoiceItemTemplate", "Invoice", "InvoiceItem", "Profile"]

--- a/models/invoice.py
+++ b/models/invoice.py
@@ -1,0 +1,81 @@
+from sqlalchemy import Column, Integer, String, DateTime, Numeric, ForeignKey, Text, Enum
+from sqlalchemy.orm import relationship
+from datetime import datetime
+from db import Base
+import enum
+
+
+class InvoiceStatus(str, enum.Enum):
+    unpaid = "unpaid"
+    paid = "paid"
+
+
+class Client(Base):
+    __tablename__ = "clients"
+    __table_args__ = {"schema": "app"}
+
+    client_id = Column(Integer, primary_key=True, autoincrement=True)
+    user_id = Column(Integer, ForeignKey("app.users.user_id"), nullable=False)
+    name = Column(String(100), nullable=False)
+    contact_name = Column(String(100))
+    address = Column(String(255))
+    email = Column(String(255))
+    created_at = Column(DateTime, default=datetime.now)
+
+    invoices = relationship("Invoice", back_populates="client")
+
+
+class InvoiceItemTemplate(Base):
+    __tablename__ = "invoice_item_templates"
+    __table_args__ = {"schema": "app"}
+
+    template_id = Column(Integer, primary_key=True, autoincrement=True)
+    user_id = Column(Integer, ForeignKey("app.users.user_id"), nullable=False)
+    name = Column(String(100), nullable=False)
+    unit_price = Column(Numeric(12, 0), nullable=False)
+    tax_rate = Column(Numeric(4, 2), nullable=False, default=0.10)
+
+
+class Invoice(Base):
+    __tablename__ = "invoices"
+    __table_args__ = {"schema": "app"}
+
+    invoice_id = Column(Integer, primary_key=True, autoincrement=True)
+    user_id = Column(Integer, ForeignKey("app.users.user_id"), nullable=False)
+    client_id = Column(Integer, ForeignKey("app.clients.client_id"), nullable=False)
+    invoice_number = Column(String(20), nullable=False)
+    issued_at = Column(DateTime, nullable=False)
+    due_at = Column(DateTime, nullable=False)
+    status = Column(String(10), nullable=False, default=InvoiceStatus.unpaid)
+    notes = Column(Text)
+    created_at = Column(DateTime, default=datetime.now)
+
+    client = relationship("Client", back_populates="invoices")
+    items = relationship("InvoiceItem", back_populates="invoice", cascade="all, delete-orphan")
+
+
+class InvoiceItem(Base):
+    __tablename__ = "invoice_items"
+    __table_args__ = {"schema": "app"}
+
+    item_id = Column(Integer, primary_key=True, autoincrement=True)
+    invoice_id = Column(Integer, ForeignKey("app.invoices.invoice_id"), nullable=False)
+    name = Column(String(100), nullable=False)
+    quantity = Column(Integer, nullable=False, default=1)
+    unit_price = Column(Numeric(12, 0), nullable=False)
+    tax_rate = Column(Numeric(4, 2), nullable=False, default=0.10)
+
+    invoice = relationship("Invoice", back_populates="items")
+
+
+class Profile(Base):
+    __tablename__ = "profiles"
+    __table_args__ = {"schema": "app"}
+
+    profile_id = Column(Integer, primary_key=True, autoincrement=True)
+    user_id = Column(Integer, ForeignKey("app.users.user_id"), nullable=False, unique=True)
+    display_name = Column(String(100), nullable=False)
+    company_name = Column(String(100))
+    address = Column(String(255))
+    phone = Column(String(20))
+    bank_info = Column(Text)

--- a/routers/invoice.py
+++ b/routers/invoice.py
@@ -1,0 +1,231 @@
+from decimal import Decimal
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+import db
+import cruds.invoice as crud
+import schemas.invoice as s
+from auth import get_current_user
+import models.user as user_model
+import models.invoice as m
+
+router = APIRouter(tags=["Invoices"], prefix="/invoices")
+
+
+# ===== 変換ヘルパー =====
+
+def to_item_schema(item: m.InvoiceItem) -> s.InvoiceItemSchema:
+    subtotal = Decimal(str(item.unit_price)) * item.quantity
+    tax_amount = (subtotal * Decimal(str(item.tax_rate))).quantize(Decimal("1"))
+    return s.InvoiceItemSchema(
+        item_id=item.item_id,
+        name=item.name,
+        quantity=item.quantity,
+        unit_price=Decimal(str(item.unit_price)),
+        tax_rate=Decimal(str(item.tax_rate)),
+        subtotal=subtotal,
+        tax_amount=tax_amount,
+        total=subtotal + tax_amount,
+    )
+
+
+def to_invoice_schema(invoice: m.Invoice) -> s.InvoiceSchema:
+    items = [to_item_schema(i) for i in invoice.items]
+    subtotal = sum(i.subtotal for i in items)
+    tax_amount = sum(i.tax_amount for i in items)
+    return s.InvoiceSchema(
+        invoice_id=invoice.invoice_id,
+        invoice_number=invoice.invoice_number,
+        client_id=invoice.client_id,
+        client_name=invoice.client.name,
+        issued_at=invoice.issued_at,
+        due_at=invoice.due_at,
+        status=invoice.status,
+        notes=invoice.notes,
+        items=items,
+        subtotal=subtotal,
+        tax_amount=tax_amount,
+        total=subtotal + tax_amount,
+        created_at=invoice.created_at,
+    )
+
+
+def to_invoice_list_schema(invoice: m.Invoice) -> s.InvoiceListSchema:
+    items = [to_item_schema(i) for i in invoice.items]
+    total = sum(i.total for i in items)
+    return s.InvoiceListSchema(
+        invoice_id=invoice.invoice_id,
+        invoice_number=invoice.invoice_number,
+        client_name=invoice.client.name,
+        issued_at=invoice.issued_at,
+        due_at=invoice.due_at,
+        status=invoice.status,
+        total=total,
+        created_at=invoice.created_at,
+    )
+
+
+# ===== 取引先 =====
+
+@router.get("/clients", response_model=list[s.ClientSchema])
+async def list_clients(
+    session: AsyncSession = Depends(db.get_dbsession),
+    current_user: user_model.User = Depends(get_current_user),
+):
+    return await crud.get_clients(session, current_user.user_id)
+
+
+@router.post("/clients", response_model=s.ClientSchema, status_code=201)
+async def create_client(
+    data: s.ClientCreateSchema,
+    session: AsyncSession = Depends(db.get_dbsession),
+    current_user: user_model.User = Depends(get_current_user),
+):
+    return await crud.create_client(session, data, current_user.user_id)
+
+
+@router.put("/clients/{client_id}", response_model=s.ClientSchema)
+async def update_client(
+    client_id: int,
+    data: s.ClientCreateSchema,
+    session: AsyncSession = Depends(db.get_dbsession),
+    current_user: user_model.User = Depends(get_current_user),
+):
+    client = await crud.update_client(session, client_id, data, current_user.user_id)
+    if not client:
+        raise HTTPException(status_code=404, detail="取引先が見つかりません")
+    return client
+
+
+@router.delete("/clients/{client_id}", status_code=204)
+async def delete_client(
+    client_id: int,
+    session: AsyncSession = Depends(db.get_dbsession),
+    current_user: user_model.User = Depends(get_current_user),
+):
+    result = await crud.delete_client(session, client_id, current_user.user_id)
+    if not result:
+        raise HTTPException(status_code=404, detail="取引先が見つかりません")
+
+
+# ===== 品目テンプレート =====
+
+@router.get("/templates", response_model=list[s.ItemTemplateSchema])
+async def list_templates(
+    session: AsyncSession = Depends(db.get_dbsession),
+    current_user: user_model.User = Depends(get_current_user),
+):
+    return await crud.get_templates(session, current_user.user_id)
+
+
+@router.post("/templates", response_model=s.ItemTemplateSchema, status_code=201)
+async def create_template(
+    data: s.ItemTemplateCreateSchema,
+    session: AsyncSession = Depends(db.get_dbsession),
+    current_user: user_model.User = Depends(get_current_user),
+):
+    return await crud.create_template(session, data, current_user.user_id)
+
+
+@router.delete("/templates/{template_id}", status_code=204)
+async def delete_template(
+    template_id: int,
+    session: AsyncSession = Depends(db.get_dbsession),
+    current_user: user_model.User = Depends(get_current_user),
+):
+    result = await crud.delete_template(session, template_id, current_user.user_id)
+    if not result:
+        raise HTTPException(status_code=404, detail="テンプレートが見つかりません")
+
+
+# ===== 請求書 =====
+
+@router.get("/", response_model=list[s.InvoiceListSchema])
+async def list_invoices(
+    status: str | None = None,
+    client_id: int | None = None,
+    session: AsyncSession = Depends(db.get_dbsession),
+    current_user: user_model.User = Depends(get_current_user),
+):
+    invoices = await crud.get_invoices(session, current_user.user_id, status=status, client_id=client_id)
+    return [to_invoice_list_schema(inv) for inv in invoices]
+
+
+@router.post("/", response_model=s.InvoiceSchema, status_code=201)
+async def create_invoice(
+    data: s.InvoiceCreateSchema,
+    session: AsyncSession = Depends(db.get_dbsession),
+    current_user: user_model.User = Depends(get_current_user),
+):
+    invoice = await crud.create_invoice(session, data, current_user.user_id)
+    invoice = await crud.get_invoice(session, invoice.invoice_id, current_user.user_id)
+    return to_invoice_schema(invoice)
+
+
+@router.get("/{invoice_id}", response_model=s.InvoiceSchema)
+async def get_invoice(
+    invoice_id: int,
+    session: AsyncSession = Depends(db.get_dbsession),
+    current_user: user_model.User = Depends(get_current_user),
+):
+    invoice = await crud.get_invoice(session, invoice_id, current_user.user_id)
+    if not invoice:
+        raise HTTPException(status_code=404, detail="請求書が見つかりません")
+    return to_invoice_schema(invoice)
+
+
+@router.put("/{invoice_id}", response_model=s.InvoiceSchema)
+async def update_invoice(
+    invoice_id: int,
+    data: s.InvoiceUpdateSchema,
+    session: AsyncSession = Depends(db.get_dbsession),
+    current_user: user_model.User = Depends(get_current_user),
+):
+    invoice = await crud.update_invoice(session, invoice_id, data, current_user.user_id)
+    if not invoice:
+        raise HTTPException(status_code=404, detail="請求書が見つかりません")
+    invoice = await crud.get_invoice(session, invoice_id, current_user.user_id)
+    return to_invoice_schema(invoice)
+
+
+@router.patch("/{invoice_id}/status", response_model=s.InvoiceSchema)
+async def patch_status(
+    invoice_id: int,
+    data: s.InvoicePatchSchema,
+    session: AsyncSession = Depends(db.get_dbsession),
+    current_user: user_model.User = Depends(get_current_user),
+):
+    invoice = await crud.patch_invoice_status(session, invoice_id, data.status, current_user.user_id)
+    if not invoice:
+        raise HTTPException(status_code=404, detail="請求書が見つかりません")
+    invoice = await crud.get_invoice(session, invoice_id, current_user.user_id)
+    return to_invoice_schema(invoice)
+
+
+@router.delete("/{invoice_id}", status_code=204)
+async def delete_invoice(
+    invoice_id: int,
+    session: AsyncSession = Depends(db.get_dbsession),
+    current_user: user_model.User = Depends(get_current_user),
+):
+    result = await crud.delete_invoice(session, invoice_id, current_user.user_id)
+    if not result:
+        raise HTTPException(status_code=404, detail="請求書が見つかりません")
+
+
+# ===== プロフィール =====
+
+@router.get("/profile/me", response_model=s.ProfileSchema | None)
+async def get_profile(
+    session: AsyncSession = Depends(db.get_dbsession),
+    current_user: user_model.User = Depends(get_current_user),
+):
+    return await crud.get_profile(session, current_user.user_id)
+
+
+@router.put("/profile/me", response_model=s.ProfileSchema)
+async def upsert_profile(
+    data: s.ProfileCreateSchema,
+    session: AsyncSession = Depends(db.get_dbsession),
+    current_user: user_model.User = Depends(get_current_user),
+):
+    return await crud.upsert_profile(session, data, current_user.user_id)

--- a/schemas/invoice.py
+++ b/schemas/invoice.py
@@ -1,0 +1,124 @@
+from pydantic import BaseModel, Field
+from datetime import datetime
+from decimal import Decimal
+from typing import Literal
+
+
+# ===== Client =====
+
+class ClientCreateSchema(BaseModel):
+    name: str = Field(..., min_length=1, max_length=100)
+    contact_name: str | None = None
+    address: str | None = None
+    email: str | None = None
+
+
+class ClientSchema(ClientCreateSchema):
+    client_id: int
+    created_at: datetime
+
+    class Config:
+        from_attributes = True
+
+
+# ===== InvoiceItemTemplate =====
+
+class ItemTemplateCreateSchema(BaseModel):
+    name: str = Field(..., min_length=1, max_length=100)
+    unit_price: Decimal = Field(..., ge=0)
+    tax_rate: Decimal = Field(Decimal("0.10"), ge=0, le=1)
+
+
+class ItemTemplateSchema(ItemTemplateCreateSchema):
+    template_id: int
+
+    class Config:
+        from_attributes = True
+
+
+# ===== InvoiceItem =====
+
+class InvoiceItemCreateSchema(BaseModel):
+    name: str = Field(..., min_length=1, max_length=100)
+    quantity: int = Field(..., ge=1)
+    unit_price: Decimal = Field(..., ge=0)
+    tax_rate: Decimal = Field(Decimal("0.10"), ge=0, le=1)
+
+
+class InvoiceItemSchema(InvoiceItemCreateSchema):
+    item_id: int
+    subtotal: Decimal
+    tax_amount: Decimal
+    total: Decimal
+
+    class Config:
+        from_attributes = True
+
+
+# ===== Invoice =====
+
+class InvoiceCreateSchema(BaseModel):
+    client_id: int
+    issued_at: datetime
+    due_at: datetime
+    notes: str | None = None
+    items: list[InvoiceItemCreateSchema] = Field(..., min_length=1)
+
+
+class InvoiceUpdateSchema(BaseModel):
+    client_id: int
+    issued_at: datetime
+    due_at: datetime
+    notes: str | None = None
+    items: list[InvoiceItemCreateSchema] = Field(..., min_length=1)
+
+
+class InvoicePatchSchema(BaseModel):
+    status: Literal["unpaid", "paid"]
+
+
+class InvoiceSchema(BaseModel):
+    invoice_id: int
+    invoice_number: str
+    client_id: int
+    client_name: str
+    issued_at: datetime
+    due_at: datetime
+    status: str
+    notes: str | None
+    items: list[InvoiceItemSchema]
+    subtotal: Decimal
+    tax_amount: Decimal
+    total: Decimal
+    created_at: datetime
+
+    class Config:
+        from_attributes = True
+
+
+class InvoiceListSchema(BaseModel):
+    invoice_id: int
+    invoice_number: str
+    client_name: str
+    issued_at: datetime
+    due_at: datetime
+    status: str
+    total: Decimal
+    created_at: datetime
+
+
+# ===== Profile =====
+
+class ProfileCreateSchema(BaseModel):
+    display_name: str = Field(..., min_length=1, max_length=100)
+    company_name: str | None = None
+    address: str | None = None
+    phone: str | None = None
+    bank_info: str | None = None
+
+
+class ProfileSchema(ProfileCreateSchema):
+    profile_id: int
+
+    class Config:
+        from_attributes = True


### PR DESCRIPTION
## Summary

請求書管理機能のフロントエンドを実装。

- **ナビゲーション**: ヘッダーにメモ / 請求書 / 取引先 / 設定のリンクを追加
- **請求書一覧** (`/invoices`): 未入金合計サマリー表示、入金ステータスをワンクリックで切り替え、絞り込みフィルター
- **請求書作成** (`/invoices/create`): 明細行を動的に追加・削除、リアルタイムで税込合計を計算
- **請求書詳細** (`/invoices/:id`): 明細・合計・ステータス確認
- **取引先管理** (`/clients`): 同一画面内で追加・編集・削除
- **プロフィール設定** (`/profile`): 氏名・屋号・口座情報を登録

## Test plan

- [ ] 取引先を登録し、請求書作成画面のプルダウンに表示されること
- [ ] 明細行を追加・削除しながら税込合計がリアルタイムで更新されること
- [ ] 請求書を作成すると詳細画面に遷移すること
- [ ] 一覧画面でステータスをクリックすると未入金↔入金済みが切り替わること
- [ ] 未入金合計サマリーが正しく計算されること
- [ ] プロフィールを保存して再読み込みしても値が残ること